### PR TITLE
enh: fix image building and use convenience functions for tests that build images

### DIFF
--- a/neurodocker/docker_api.py
+++ b/neurodocker/docker_api.py
@@ -78,11 +78,16 @@ class Dockerfile(object):
 
     def __init__(self, specs, pkg_manager=None, check_urls=True):
         self.specs = specs
-        self.pkg_manager = pkg_manager
-        self.check_urls = check_urls
 
-        if self.pkg_manager is None:
+        try:
             self.pkg_manager = self.specs['pkg_manager']
+        except KeyError:
+            self.pkg_manager = pkg_manager
+
+        try:
+            self.check_urls = self.specs['check_urls']
+        except KeyError:
+            self.check_urls = check_urls
 
         self.cmd = self._create_cmd()
 
@@ -143,7 +148,7 @@ class Dockerfile(object):
         return "\n\n".join(cmds)
 
     def save(self, filepath="Dockerfile", **kwargs):
-        """Save `self.cmd` to `filepath`. `kwargs` are for `open()`."""
+        """Save Dockerfile to `filepath`. `kwargs` are for `open()`."""
         if not self.cmd:
             raise Exception("Instructions are empty.")
         with open(filepath, mode='w', **kwargs) as fp:

--- a/neurodocker/docker_api.py
+++ b/neurodocker/docker_api.py
@@ -321,8 +321,8 @@ class DockerContainer(object):
         filters = {'status': 'running'}
         try:
             self.container.stop()
-        except:
-            if container.container in client.containers.list(filters=filters):
+        except requests.exceptions.ReadTimeout:
+            if self.container in client.containers.list(filters=filters):
                 raise docker.errors.APIError("Container not stopped properly.")
 
         if remove:

--- a/neurodocker/interfaces/tests/test_ants.py
+++ b/neurodocker/interfaces/tests/test_ants.py
@@ -3,10 +3,10 @@
 from __future__ import absolute_import, division, print_function
 from io import BytesIO
 
-from neurodocker.docker_api import (client, Dockerfile, DockerImage,
-                                    DockerContainer)
+from neurodocker.docker_api import Dockerfile, DockerImage, DockerContainer
 from neurodocker.parser import SpecsParser
 from neurodocker.interfaces import ANTs
+from neurodocker.interfaces.tests import utils
 
 
 class TestANTs(object):
@@ -18,16 +18,10 @@ class TestANTs(object):
                  'pkg_manager': 'yum',
                  'check_urls': False,
                  'ants': {'version': '2.1.0', 'use_binaries': True}}
-        parser = SpecsParser(specs)
-        cmd = Dockerfile(parser.specs).cmd
-        image = DockerImage(fileobj=cmd).build_raw()
-        container = DockerContainer(image)
-        container.start()
+        container = utils.get_container_from_specs(specs)
         output = container.exec_run('Atropos')
         assert "error" not in output, "error running Atropos"
-        container.cleanup(remove=True, force=True)
-        client.containers.prune()
-        client.images.prune()
+        utils.test_cleanup(container)
 
     def test_build_from_source_github(self):
         # TODO: expand on tests for building ANTs from source. It probably

--- a/neurodocker/interfaces/tests/test_ants.py
+++ b/neurodocker/interfaces/tests/test_ants.py
@@ -1,10 +1,7 @@
 """Tests for neurodocker.interfaces.ANTs"""
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
 from __future__ import absolute_import, division, print_function
-from io import BytesIO
 
-from neurodocker.docker_api import Dockerfile, DockerImage, DockerContainer
-from neurodocker.parser import SpecsParser
 from neurodocker.interfaces import ANTs
 from neurodocker.interfaces.tests import utils
 

--- a/neurodocker/interfaces/tests/test_fsl.py
+++ b/neurodocker/interfaces/tests/test_fsl.py
@@ -1,12 +1,9 @@
 """Tests for neurodocker.interfaces.FSL"""
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
 from __future__ import absolute_import, division, print_function
-from io import BytesIO
 
 import pytest
 
-from neurodocker.docker_api import Dockerfile, DockerImage, DockerContainer
-from neurodocker.parser import SpecsParser
 from neurodocker.interfaces import FSL
 from neurodocker.interfaces.tests import utils
 
@@ -19,13 +16,13 @@ class TestFSL(object):
         specs = {'base': 'centos:7',
                  'pkg_manager': 'yum',
                  'check_urls': False,
-                 'fsl': {'version': '5.0.9', 'use_installer': True}}
+                 'fsl': {'version': '5.0.10', 'use_installer': True}}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('bet')
         assert "error" not in output, "error running bet"
         utils.test_cleanup(container)
 
-    def test_build_image_fsl_508_binaries_xenial(self):
+    def test_build_image_fsl_509_binaries_xenial(self):
         """Install FSL binaries on Ubuntu Xenial."""
         specs = {'base': 'ubuntu:xenial',
                  'pkg_manager': 'apt',

--- a/neurodocker/interfaces/tests/test_fsl.py
+++ b/neurodocker/interfaces/tests/test_fsl.py
@@ -5,11 +5,10 @@ from io import BytesIO
 
 import pytest
 
-from neurodocker.docker_api import (client, Dockerfile, DockerImage,
-                                    DockerContainer)
+from neurodocker.docker_api import Dockerfile, DockerImage, DockerContainer
 from neurodocker.parser import SpecsParser
 from neurodocker.interfaces import FSL
-
+from neurodocker.interfaces.tests import utils
 
 class TestFSL(object):
     """Tests for FSL class."""
@@ -21,16 +20,10 @@ class TestFSL(object):
                  'pkg_manager': 'yum',
                  'check_urls': False,
                  'fsl': {'version': '5.0.9', 'use_installer': True}}
-        parser = SpecsParser(specs)
-        cmd = Dockerfile(parser.specs).cmd
-        image = DockerImage(fileobj=cmd).build_raw()
-        container = DockerContainer(image)
-        container.start()
+        container = utils.get_container_from_specs(specs)
         output = container.exec_run('bet')
         assert "error" not in output, "error running bet"
-        container.cleanup(remove=True, force=True)
-        client.containers.prune()
-        client.images.prune()
+        utils.test_cleanup(container)
 
     def test_build_image_fsl_508_binaries_xenial(self):
         """Install FSL binaries on Ubuntu Xenial."""
@@ -38,13 +31,7 @@ class TestFSL(object):
                  'pkg_manager': 'apt',
                  'check_urls': False,
                  'fsl': {'version': '5.0.9', 'use_binaries': True}}
-        parser = SpecsParser(specs)
-        cmd = Dockerfile(parser.specs).cmd
-        image = DockerImage(fileobj=cmd).build_raw()
-        container = DockerContainer(image)
-        container.start()
+        container = utils.get_container_from_specs(specs)
         output = container.exec_run('bet')
         assert "error" not in output, "error running bet"
-        container.cleanup(remove=True, force=True)
-        client.containers.prune()
-        client.images.prune()
+        utils.test_cleanup(container)

--- a/neurodocker/interfaces/tests/test_miniconda.py
+++ b/neurodocker/interfaces/tests/test_miniconda.py
@@ -1,10 +1,7 @@
 """Tests for neurodocker.interfaces.Miniconda"""
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
 from __future__ import absolute_import, division, print_function
-from io import BytesIO
 
-from neurodocker.docker_api import Dockerfile, DockerImage, DockerContainer
-from neurodocker.parser import SpecsParser
 from neurodocker.interfaces import Miniconda
 from neurodocker.interfaces.tests import utils
 

--- a/neurodocker/interfaces/tests/test_spm.py
+++ b/neurodocker/interfaces/tests/test_spm.py
@@ -3,11 +3,10 @@
 from __future__ import absolute_import, division, print_function
 from io import BytesIO
 
-from neurodocker.docker_api import (client, Dockerfile, DockerImage,
-                                    DockerContainer)
+from neurodocker.docker_api import Dockerfile, DockerImage, DockerContainer
 from neurodocker.parser import SpecsParser
 from neurodocker.interfaces import SPM
-
+from neurodocker.interfaces.tests import utils
 
 class TestSPM(object):
     """Tests for SPM class."""
@@ -18,12 +17,7 @@ class TestSPM(object):
                  'pkg_manager': 'apt',
                  'check_urls': False,
                  'spm': {'version': '12', 'matlab_version': 'R2017a'}}
-        parser = SpecsParser(specs)
-        cmd = Dockerfile(parser.specs).cmd
-
-        image = DockerImage(fileobj=cmd).build_raw()
-        container = DockerContainer(image)
-        container.start(working_dir='/home')
+        container = utils.get_container_from_specs(specs, working_dir='/home')
 
         cmd = ["/bin/sh", "-c", """echo 'fprintf("desired output")' > test.m """]
         container.exec_run(cmd)
@@ -31,6 +25,4 @@ class TestSPM(object):
         output = container.exec_run(cmd)
         assert "error" not in output.lower(), "error running SPM command"
         assert "desired output" in output, "expected output not found"
-        container.cleanup(remove=True, force=True)
-        client.containers.prune()
-        client.images.prune()
+        utils.test_cleanup(container)

--- a/neurodocker/interfaces/tests/test_spm.py
+++ b/neurodocker/interfaces/tests/test_spm.py
@@ -1,10 +1,7 @@
 """Tests for neurodocker.interfaces.SPM"""
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
 from __future__ import absolute_import, division, print_function
-from io import BytesIO
 
-from neurodocker.docker_api import Dockerfile, DockerImage, DockerContainer
-from neurodocker.parser import SpecsParser
 from neurodocker.interfaces import SPM
 from neurodocker.interfaces.tests import utils
 

--- a/neurodocker/interfaces/tests/utils.py
+++ b/neurodocker/interfaces/tests/utils.py
@@ -1,0 +1,17 @@
+"""Utility functions for `neurodocker.interfaces.tests`."""
+from __future__ import absolute_import
+
+from neurodocker import Dockerfile, DockerImage, DockerContainer, SpecsParser
+from neurodocker.docker_api import client
+
+def get_container_from_specs(specs, **kwargs):
+    """Return started container. `kwargs` are for `container.start()`."""
+    parser = SpecsParser(specs)
+    df = Dockerfile(parser.specs)
+    image = DockerImage(df).build()
+    return DockerContainer(image).start(**kwargs)
+
+def test_cleanup(container):
+    container.cleanup(remove=True, force=True)
+    client.containers.prune()
+    client.images.prune()

--- a/neurodocker/interfaces/tests/utils.py
+++ b/neurodocker/interfaces/tests/utils.py
@@ -8,10 +8,10 @@ def get_container_from_specs(specs, **kwargs):
     """Return started container. `kwargs` are for `container.start()`."""
     parser = SpecsParser(specs)
     df = Dockerfile(parser.specs)
-    image = DockerImage(df).build()
+    image = DockerImage(df).build(log_console=True)
     return DockerContainer(image).start(**kwargs)
 
 def test_cleanup(container):
-    container.cleanup(remove=True, force=True)
+    container.cleanup()
     client.containers.prune()
     client.images.prune()

--- a/neurodocker/tests/test_docker_api.py
+++ b/neurodocker/tests/test_docker_api.py
@@ -105,11 +105,13 @@ class TestBuildOutputLogger(object):
         logger = BuildOutputLogger(logs, console=False, filepath=self.filepath.strpath)
         logger.daemon = True
         logger.start()
-        assert logger.is_alive(), "BuildOutputLogger not alive"
+        living = logger.is_alive()
+        assert living, "BuildOutputLogger not alive"
 
         while logger.is_alive():
             pass
-        assert self.filepath.read(), "log file empty"
+        content = self.filepath.read()
+        assert content, "log file empty"
 
     def test_get_logs(self):
         logs = client.api.build(fileobj=self.fileobj, rm=True)
@@ -139,12 +141,13 @@ class TestDockerImage(object):
         # Correct instructions.
         cmd = "FROM alpine:latest"
         image = DockerImage(cmd).build()
-        assert isinstance(image, docker.models.images.Image)
+        correct_type = isinstance(image, docker.models.images.Image)
+        assert correct_type
 
         # Incorrect instructions
         cmd = "FROM ubuntu:fake_version_12345"
         with pytest.raises(docker.errors.BuildError):
-            img = DockerImage(cmd).build()
+            DockerImage(cmd).build()
 
 
 class TestDockerContainer(object):

--- a/neurodocker/tests/test_docker_api.py
+++ b/neurodocker/tests/test_docker_api.py
@@ -10,7 +10,7 @@ import docker
 import pytest
 
 from neurodocker.docker_api import (docker_is_running, Dockerfile, DockerImage,
-                                    DockerContainer, RawOutputLogger,
+                                    DockerContainer, BuildOutputLogger,
                                     require_docker)
 from neurodocker.interfaces import ANTs, FSL, Miniconda, SPM
 
@@ -92,7 +92,7 @@ class TestDockerfile(object):
             df.save(filepath.strpath)
 
 
-class TestRawOutputLogger(object):
+class TestBuildOutputLogger(object):
     @pytest.fixture(autouse=True)
     def setup(self, tmpdir):
         self.tmpdir = tmpdir
@@ -102,21 +102,18 @@ class TestRawOutputLogger(object):
 
     def test_start(self):
         logs = client.api.build(fileobj=self.fileobj, rm=True)
-        logger = RawOutputLogger(logs, console=False, filepath=self.filepath.strpath)
+        logger = BuildOutputLogger(logs, console=False, filepath=self.filepath.strpath)
         logger.daemon = True
         logger.start()
-        assert logger.is_alive(), "RawOutputLogger not alive!"
+        assert logger.is_alive(), "BuildOutputLogger not alive"
 
         while logger.is_alive():
             pass
-        image = client.images.get(logger.id)
-        assert isinstance(image, docker.models.images.Image), "image is not a Docker image!"
-
         assert self.filepath.read(), "log file empty"
 
     def test_get_logs(self):
         logs = client.api.build(fileobj=self.fileobj, rm=True)
-        logger = RawOutputLogger(logs, console=True)
+        logger = BuildOutputLogger(logs, console=True)
         logger.daemon = True
         logger.start()
 
@@ -126,48 +123,34 @@ class TestRawOutputLogger(object):
 
 
 class TestDockerImage(object):
-    @pytest.fixture(autouse=True)
-    def setup(self, tmpdir):
-        self.tmpdir = tmpdir
-        self.filepath = self.tmpdir.join("Dockerfile")
 
     def test___init__(self):
-        with pytest.raises(ValueError):
-            DockerImage()
+        with pytest.raises(TypeError):
+            DockerImage(dict())
 
-    def test_build_from_file(self):
-        self.filepath.write("FROM alpine:latest\n")
-        assert DockerImage(path=self.tmpdir.strpath).build()
+        specs = {'base': 'debian:jessie',
+                 'pkg_manager': 'apt'}
+        df = Dockerfile(specs=specs)
+        # Test that fileobj is a file object.
+        image = DockerImage(df)
+        assert image.fileobj.read()
 
     def test_build(self):
         # Correct instructions.
         cmd = "FROM alpine:latest"
-        img = DockerImage(fileobj=cmd)
-        assert isinstance(img.build(), docker.models.images.Image)
+        image = DockerImage(cmd).build()
+        assert isinstance(image, docker.models.images.Image)
 
         # Incorrect instructions
         cmd = "FROM ubuntu:fake_version_12345"
-        img = DockerImage(fileobj=cmd)
         with pytest.raises(docker.errors.BuildError):
-            img.build()
-
-    def test_build_raw(self):
-        # Correct instructions.
-        cmd = "FROM alpine:latest"
-        img = DockerImage(fileobj=cmd)
-        assert isinstance(img.build_raw(), docker.models.images.Image)
-
-        # Incorrect instructions
-        cmd = "FROM ubuntu:fake_version_12345"
-        img = DockerImage(fileobj=cmd)
-        with pytest.raises(docker.errors.BuildError):
-            img.build_raw()
+            img = DockerImage(cmd).build()
 
 
 class TestDockerContainer(object):
     @pytest.fixture(autouse=True)
     def setup(self):
-        self.image = DockerImage(fileobj='FROM ubuntu:17.04').build()
+        self.image = DockerImage('FROM ubuntu:17.04').build()
 
     def test_start_cleanup(self):
         pre = client.containers.list()


### PR DESCRIPTION
Several updates:

- `DockerImage` now only has a `.build()` method, which can stream the raw build output and check for build errors.
- `DockerImage` can accept an instance of `Dockerfile` or a string.
- Fix the `require_docker` decorator to preserve docstrings and arguments.
- Fix the `DockerContainer.cleanup()` method to check whether the container was stopped and raise error if not.
- Update tests to reflect these changes.
- Remove one redundant `Miniconda` test.