### PR TITLE
enh: add command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,23 @@
 [![codecov](https://codecov.io/gh/kaczmarj/neurodocker/branch/master/graph/badge.svg)](https://codecov.io/gh/kaczmarj/neurodocker)
 
 
-_Neurodocker_ is a Python project that generates Docker images with specified versions of Python and neuroimaging software. The project is used for regression testing of [Nipype](https://github.com/nipy/nipype/) interfaces. See the [example](#example) at the bottom of this page.
+_Neurodocker_ is a Python project that generates Docker images with specified versions of Python and neuroimaging software. The project is used for regression testing of [Nipype](https://github.com/nipy/nipype/) interfaces. See the [full example](#example) at the bottom of this page.
 
+
+# Command-line interface
+
+A Dockerfile can be generated from the command-line with the `neurodocker` command. Use the `-h` or `--help` flag for more information.
+
+Example:
+
+```bash
+neurodocker -b ubuntu:17.04 -p apt \
+--ants version=2.1.0 \
+--fsl version=5.0.10 \
+--miniconda python_version=3.5.1 conda_install=traits,pandas pip_install=nipype \
+--spm version=12 matlab_version=R2017a \
+--no-check-urls
+```
 
 
 ## Supported Software

--- a/README.md
+++ b/README.md
@@ -10,23 +10,35 @@ _Neurodocker_ is a Python project that generates Docker images with specified ve
 
 ## Supported Software
 
-This list is growing.
+Valid options for each software package are the keyword arguments for the class that installs that package. These classes live in [`neurodocker.interfaces`](neurodocker/interfaces/). The default installation behavior for every software package (except Miniconda) is to install by downloading and un-compressing the binaries.
 
 ### ANTs
 
-To install, include `'ants'` (case-insensitive) in the specifications dictionary. Valid keys within `'ants'` are keywords for [`neurodocker.interfaces.ANTs`](neurodocker/interfaces/ants.py#L27). Pre-compiled binaries can be installed, or ANTs can be compiled from source.
+ANTs can be installed using pre-compiled binaries (default behavior), or it can be built from source (takes about 45 minutes). To install ANTs, include `'ants'` (case-insensitive) in the specifications dictionary. Valid options are `'version'` (e.g., `'2.1.0'`) and `'use_binaries'` (if true, use binaries; if false, build from source).
 
-### Conda
-
-To install, include `'miniconda'` (case-insensitive) in the specifications dictionary. Valid keys within `'miniconda'` are keywords for [`neurodocker.interfaces.Miniconda`](neurodocker/interfaces/miniconda.py#L12). The `conda-forge` channel is added by default.
+View source: [`neurodocker.interfaces.ANTs`](neurodocker/interfaces/ants.py).
 
 ### FSL
 
-To install, include `'fsl'` (case-insensitive) in the specifications dictionary. Valid keys within `'fsl'` are keywords for [`neurodocker.interfaces.FSL`](neurodocker/interfaces/fsl.py#L11). Beware that FSL's Python installer will panic if used on a Debian-based system.
+FSL can be installed using pre-compiled binaries (default behavior), FSL's Python installer (not on Debian-based systems), or through NeuroDebian. To install FSL, include `'fsl'` (case-insensitive) in the specifications dictionary. Valid options are `'version'` (e.g., `'5.0.10'`), `'use_binaries'` (bool), `'use_installer'` (bool; to use FSL's Python installer), `'use_neurodebian'` (bool), and `'os_codename'` (e.g., `'jessie'` or `'xenial'`; only required if installing with NeuroDebian).
+
+View source: [`neurodocker.interfaces.FSL`](neurodocker/interfaces/fsl.py).
+
+
+### Miniconda
+
+Miniconda is installed using Miniconda's BASH installer. The latest version of Python 3 is installed to the root environment, and the `conda-forge` channel is added. A new conda environment is created with the requested specifications, the root environment is removed (to save space), and the new environment is prepended to `PATH`. To install Miniconda, include `'miniconda'` (case-insensitive) in the specifications dictionary Valid options are `'python_version'` (required; e.g., `'3.5.1'`), `'conda_install'` (e.g., `['numpy', 'traits']`), `pip_install` (e.g., `['nipype', 'pytest']`), and `miniconda_version` (`'latest'` by default).
+
+View source: [`neurodocker.interfaces.Miniconda`](neurodocker/interfaces/miniconda.py).
+
 
 ### SPM
 
-To install, include `'spm'` (case-insensitive) in the specifications dictionary. Valid keys within `'spm'` are keywords for [`neurodocker.interfaces.SPM`](neurodocker/interfaces/spm.py#L17). Currently, only SPM12 and MATLAB R2017a are supported.
+The standalone version of SPM is installed, along with its dependency Matlab Compiler Runtime (MCR). MCR is installed first, using the [instructions on Matlab's website](https://www.mathworks.com/help/compiler/install-the-matlab-runtime.html). SPM is then installed by downloading and unzipping the standalone SPM package. To install SPM, include `'spm'` (case-insensitive) in the specifications dictionary. Valid options are `'version'` (e.g., `'12'`), and `'matlab_version'` (case-sensitive; e.g., `'R2017a'`).
+
+Note: Currently, only SPM12 and MATLAB R2017a are supported.
+
+View source: [`neurodocker.interfaces.SPM`](neurodocker/interfaces/spm.py).
 
 
 

--- a/neurodocker/docker_api.py
+++ b/neurodocker/docker_api.py
@@ -106,7 +106,7 @@ class Dockerfile(object):
         if "miniconda" in self.specs.keys():
             cmds.append(self.add_miniconda())
         cmds.append(self.add_software())
-        return "\n\n".join(cmds)
+        return "\n\n".join(cmds) + "\n"
 
     def add_base(self):
         """Add Dockerfile FROM instruction."""
@@ -153,7 +153,6 @@ class Dockerfile(object):
             raise Exception("Instructions are empty.")
         with open(filepath, mode='w', **kwargs) as fp:
             fp.write(self.cmd)
-            fp.write('\n')
 
 
 class BuildOutputLogger(threading.Thread):

--- a/neurodocker/interfaces/fsl.py
+++ b/neurodocker/interfaces/fsl.py
@@ -24,7 +24,8 @@ class FSL(object):
     pkg_manager : {'apt', 'yum'}
         Linux package manager.
     use_binaries : bool
-        If true, use binaries from FSL's website. Defaults to True.
+        If true, use binaries from FSL's website. True by default if
+        use_installer and use_neurodebian are false.
     use_installer : bool
         If true, install FSL using FSL's Python installer. Only works on
         CentOS/RHEL.
@@ -40,7 +41,7 @@ class FSL(object):
     Look into ReproNim/simple_workflow to learn how to install specific versions
     of FSL on Debian (https://github.com/ReproNim/simple_workflow).
     """
-    def __init__(self, version, pkg_manager, use_binaries=False,
+    def __init__(self, version, pkg_manager, use_binaries=None,
                  use_installer=False, use_neurodebian=False, os_codename=None,
                  check_urls=True):
         self.version = LooseVersion(version)
@@ -50,6 +51,10 @@ class FSL(object):
         self.use_neurodebian = use_neurodebian
         self.os_codename = os_codename
         self.check_urls = check_urls
+
+        if (self.use_binaries is None and not self.use_installer
+            and not self.use_neurodebian):
+            self.use_binaries = True
 
         self._check_args()
         self.cmd = self._create_cmd()

--- a/neurodocker/main.py
+++ b/neurodocker/main.py
@@ -14,9 +14,7 @@ from __future__ import absolute_import, unicode_literals
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 import sys
 
-from neurodocker import (DockerContainer, DockerContainer, Dockerfile,
-                         SpecsParser, SUPPORTED_SOFTWARE)
-
+from neurodocker import (Dockerfile, SpecsParser, SUPPORTED_SOFTWARE)
 
 
 def create_parser():

--- a/neurodocker/main.py
+++ b/neurodocker/main.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+"""Command-line utility to generate Dockerfiles, build Docker images, run
+commands within containers, and get command ouptut.
+
+Example:
+
+    neurodocker -b ubuntu:17.04 -p apt --ants version=2.1.0 --fsl version=5.0.10
+    --miniconda python_version=3.5.1 conda_install=traits,pandas pip_install=nipype
+    --spm version=12 matlab_version=R2017a
+"""
+# Author: Jakub Kaczmarzyk <jakubk@mit.edu>
+
+from __future__ import absolute_import, unicode_literals
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+import sys
+
+from neurodocker import (DockerContainer, DockerContainer, Dockerfile,
+                         SpecsParser, SUPPORTED_SOFTWARE)
+
+
+
+def create_parser():
+    """Return command-line argument parser."""
+    parser = ArgumentParser(description=__doc__,
+                            formatter_class=RawDescriptionHelpFormatter)
+
+    # Global requirements.
+    reqs = parser.add_argument_group(title="global requirements")
+    reqs.add_argument("-b", "--base", required=True,
+                      help="Base Docker image. Eg, ubuntu:17.04")
+    reqs.add_argument("-p", "--pkg-manager", required=True,
+                      help="Linux package manager {apt, yum}")
+
+
+    # Software package options.
+    pkgs_help = {
+        "all": ("Install software packages. Each argument takes a list of "
+                "key=value pairs.\nWhere applicable, the default installation "
+                "behavior is to install by\ndownloading and uncompressing "
+                "binaries."),
+        "ants": ("Install ANTs. Valid keys are version (required) and "
+                "use_binaries (default true). If use_binaries=true, installs "
+                "pre-compiled binaries; if use_binaries=false, builds ANTs "
+                "from source."),
+        "fsl": ("Install FSL. Valid keys are version (required), use_binaries "
+                "(default true), use_installer, use_neurodebian, and "
+                "os_codename (eg, jessie)."),
+        "miniconda": ("Install Miniconda. Valid keys are python_version "
+                      "(required), conda_install, pip_install, and "
+                      "miniconda_version (defaults to latest). The keys "
+                      "conda_install and pip_install take an arbitrary number "
+                      "of comma-separated values (no white-space). "
+                      "Example: conda_install=pandas,pytest,traits)."),
+        "spm": ("Install SPM (and its dependency, Matlab Compiler Runtime). "
+                "Valid keys are version and matlab_version."),
+    }
+
+    pkgs = parser.add_argument_group(title="software package arguments",
+                                     description=pkgs_help['all'])
+
+    list_of_kv = lambda kv: kv.split("=")
+
+    for p in SUPPORTED_SOFTWARE.keys():
+        flag = "--{}".format(p)
+        pkgs.add_argument(flag, dest=p, action="append", nargs="+", metavar="",
+                          type=list_of_kv, help=pkgs_help[p])
+
+
+    # Docker-related arguments.
+    dkr = parser.add_argument_group(title="Docker-related arguments")
+    dkr.add_argument('--no-print-df', dest='no_print_df', action="store_true",
+                     help="Do not print the Dockerfile")
+    dkr.add_argument('-o', '--output', dest="output",
+                     help="If specified, save Dockerfile to file with this name.")
+    # dkr.add_argument('--build', dest="build", action="store_true")
+
+
+    # Other arguments.
+    parser.add_argument("--check-urls", dest="check_urls", action="store_true",
+                        help=("Verify communication with URLs used in "
+                              "the build."), default=True,)
+    parser.add_argument("--no-check-urls", action="store_false", dest="check_urls",
+                        help=("Do not verify communication with URLs used in "
+                              "the build."))
+    parser.add_argument("--verbose", action="store_true")
+
+    return parser
+
+
+def parse_args(args):
+    """Return namespace of command-line arguments."""
+    parser = create_parser()
+    return parser.parse_args(args)
+
+
+def convert_args_to_specs(namespace):
+    """Convert namespace of command-line arguments to dictionary compatible
+    with `neurodocker.parser.SpecsParser`.
+    """
+    from copy import deepcopy
+
+    def _list_to_dict(list_of_kv):
+        """Convert list of [key, value] pairs to a dictionary."""
+        # Flatten list.
+        if list_of_kv is not None:
+            list_of_kv = [item for sublist in list_of_kv for item in sublist]
+            return {k: v for k, v in list_of_kv}
+
+    specs = vars(deepcopy(namespace))
+
+    for pkg in SUPPORTED_SOFTWARE.keys():
+        # try:
+        specs[pkg] = _list_to_dict(specs[pkg])
+        #except KeyError:
+        #    pass
+
+    try:
+        specs['miniconda']['conda_install'] = \
+            specs['miniconda']['conda_install'].replace(',', ' ')
+    except (KeyError, TypeError):
+        pass
+
+    try:
+        specs['miniconda']['pip_install'] = \
+            specs['miniconda']['pip_install'].replace(',', ' ')
+    except (KeyError, TypeError):
+        pass
+
+    return specs
+
+
+def main(args=None):
+
+    if args is None:
+        namespace = parse_args(sys.argv[1:])
+    else:
+        namespace = parse_args(args)
+
+    # Create dictionary of specifications.
+    specs = convert_args_to_specs(namespace)
+    KEYS_TO_REMOVE = ['verbose', 'no_print_df', 'output', 'build']
+    for key in KEYS_TO_REMOVE:
+        specs.pop(key, None)
+
+    # Parse to double-check that keys are correct.
+    parser = SpecsParser(specs)
+
+    # Generate Dockerfile.
+    df = Dockerfile(parser.specs)
+    if not namespace.no_print_df:
+        print(df.cmd)
+
+    if namespace.output:
+        df.save(namespace.output)
+
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/neurodocker/parser.py
+++ b/neurodocker/parser.py
@@ -31,6 +31,7 @@ class SpecsParser(object):
 
     def parse(self):
         self._validate_keys()
+        self.specs = self._remove_nones()
         try:
             self._parse_conda_pip()
         except KeyError:
@@ -50,6 +51,9 @@ class SpecsParser(object):
             valid = ", ".join(self.VALID_TOP_LEVEL_KEYS)
             raise KeyError("Unexpected top-level key(s) in input: {}. Valid "
                            "keys are {}.".format(invalid, valid))
+
+    def _remove_nones(self):
+        return {k:v for k, v in self.specs.items() if v is not None}
 
     def _parse_conda_pip(self):
         """Parse packages to install with `conda` and/or `pip`."""

--- a/neurodocker/tests/test_main.py
+++ b/neurodocker/tests/test_main.py
@@ -1,0 +1,115 @@
+"""Tests for neurodocker.main"""
+# Author: Jakub Kaczmarzyk <jakubk@mit.edu>
+
+import sys
+
+import pytest
+
+from neurodocker.main import (create_parser, parse_args, convert_args_to_specs,
+                              main)
+
+
+def test_parse_args():
+    parser = create_parser()
+    assert parser
+
+    with pytest.raises(SystemExit):
+        parse_args([''])
+
+    with pytest.raises(SystemExit):
+        parse_args(['-b'])
+
+    with pytest.raises(SystemExit):
+        parse_args(['-p'])
+
+    iter_args = ['--ants', '--fsl', '--miniconda', '--spm']
+    for a in iter_args:
+        with pytest.raises(SystemExit):
+            parse_args([a])
+
+    base_args = "-b ubuntu:17.04 -p apt --no-check-urls".split()
+    namespace = parse_args(base_args)
+    assert namespace.base
+    assert namespace.pkg_manager
+    assert not namespace.check_urls
+    pkgs_present = (namespace.ants or namespace.fsl
+                    or namespace.miniconda or namespace.spm)
+    assert not pkgs_present
+
+    args = base_args + ['--ants', 'version=2.1.0']
+    namespace = parse_args(args)
+    assert namespace.ants
+
+    args = base_args + ['--fsl', 'version=5.0.10']
+    namespace = parse_args(args)
+    assert namespace.fsl
+
+    args = base_args + ['--miniconda', 'conda_install=pandas,traits']
+    namespace = parse_args(args)
+    assert namespace.miniconda
+
+    args = base_args + ['--spm', 'version=12']
+    namespace = parse_args(args)
+    assert namespace.spm
+
+    args = base_args + ['--no-check-urls']
+    namespace = parse_args(args)
+    assert not namespace.check_urls
+
+
+def test_convert_args_to_specs():
+
+    args = ['-b', 'ubuntu:17.04', '-p', 'apt',
+            '--ants', 'version=2.1.0',
+            '--fsl', 'version=5.0.10',
+            '--miniconda', 'conda_install=pandas,traits',
+            '--spm', 'version=12',
+            '--no-check-urls']
+    namespace = parse_args(args)
+    assert namespace
+
+    specs = convert_args_to_specs(namespace)
+    assert vars(namespace).keys() == specs.keys()
+
+    assert "," not in specs['miniconda']['conda_install']
+
+
+def test_main():
+    args = ['-b', 'ubuntu:17.04', '-p', 'apt',
+            '--ants', 'version=2.1.0',
+            '--fsl', 'version=5.0.10',
+            '--miniconda', 'python_version=3.5.1',
+            '--spm', 'version=12', 'matlab_version=R2017a',
+            '--no-check-urls']
+    main(args)
+
+    args = ['-b', 'ubuntu:17.04', '-p', 'apt', '--no-check-urls']
+    main(args)
+
+    with pytest.raises(SystemExit):
+        args = ['-b', 'ubuntu:17.04']
+        main(args)
+
+    with pytest.raises(SystemExit):
+        main()
+
+
+def test_no_print(capsys):
+    args = ['-b', 'ubuntu:17.04', '-p', 'apt', '--no-check-urls']
+    main(args)
+    out, err = capsys.readouterr()
+    assert "FROM" in out and "RUN" in out
+
+    args.append('--no-print-df')
+    main(args)
+    out, err = capsys.readouterr()
+    assert not out
+
+
+
+def test_save(tmpdir):
+    outfile = tmpdir.join("test.txt")
+    args = ['-b', 'ubuntu:17.04', '-p', 'apt', '--no-print-df', '-o',
+            outfile.strpath, '--no-check-urls']
+    main(args)
+    assert outfile.read()

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,7 @@ setup(name='neurodocker',
       author='Jakub Kaczmarzyk',
       author_email='jakubk@mit.edu',
       packages=find_packages(),
-      install_requires = ['docker>=2.2.0', 'requests>=2.0.0'],
+      install_requires = ['docker', 'requests'],
+      entry_points={'console_scripts':
+                    ['neurodocker=neurodocker.main:main']}
       )


### PR DESCRIPTION
Add command-line interface.

Example:

```bash
neurodocker -b ubuntu:17.04 -p apt \
--ants version=2.1.0 \
--fsl version=5.0.10 \
--miniconda python_version=3.5.1 conda_install=traits,pandas pip_install=nipype \
--spm version=12 matlab_version=R2017a \
--no-check-urls
```