### PR TITLE
enh: improve error checking to command-line interface

### DIFF
--- a/neurodocker/main.py
+++ b/neurodocker/main.py
@@ -102,15 +102,17 @@ def convert_args_to_specs(namespace):
         # Flatten list.
         if list_of_kv is not None:
             list_of_kv = [item for sublist in list_of_kv for item in sublist]
+
+            for kv_pair in list_of_kv:
+                if len(kv_pair) != 2:
+                    raise ValueError("Error in arguments: {}".format(kv_pair))
+
             return {k: v for k, v in list_of_kv}
 
     specs = vars(deepcopy(namespace))
 
     for pkg in SUPPORTED_SOFTWARE.keys():
-        # try:
         specs[pkg] = _list_to_dict(specs[pkg])
-        #except KeyError:
-        #    pass
 
     try:
         specs['miniconda']['conda_install'] = \
@@ -136,8 +138,8 @@ def main(args=None):
 
     # Create dictionary of specifications.
     specs = convert_args_to_specs(namespace)
-    KEYS_TO_REMOVE = ['verbose', 'no_print_df', 'output', 'build']
-    for key in KEYS_TO_REMOVE:
+    keys_to_remove = ['verbose', 'no_print_df', 'output', 'build']
+    for key in keys_to_remove:
         specs.pop(key, None)
 
     # Parse to double-check that keys are correct.
@@ -150,7 +152,6 @@ def main(args=None):
 
     if namespace.output:
         df.save(namespace.output)
-
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/neurodocker/main.py
+++ b/neurodocker/main.py
@@ -4,8 +4,12 @@ commands within containers, and get command ouptut.
 
 Example:
 
-    neurodocker -b ubuntu:17.04 -p apt --ants version=2.1.0 --fsl version=5.0.10
-    --miniconda python_version=3.5.1 conda_install=traits,pandas pip_install=nipype
+    neurodocker -b ubuntu:17.04 -p apt \
+    --ants version=2.1.0 \
+    --fsl version=5.0.10 \
+    --miniconda python_version=3.5.1 \
+                conda_install=traits,pandas \
+                pip_install=nipype \
     --spm version=12 matlab_version=R2017a
 """
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
@@ -105,7 +109,10 @@ def convert_args_to_specs(namespace):
 
             for kv_pair in list_of_kv:
                 if len(kv_pair) != 2:
-                    raise ValueError("Error in arguments: {}".format(kv_pair))
+                    raise ValueError("Error in arguments '{}'. Did you forget "
+                                     "the equals sign?".format(kv_pair[0]))
+                if not kv_pair[-1]:
+                    raise ValueError("Option required for '{}'".format(kv_pair[0]))
 
             return {k: v for k, v in list_of_kv}
 

--- a/neurodocker/tests/test_dockerfile.py
+++ b/neurodocker/tests/test_dockerfile.py
@@ -73,8 +73,3 @@ class TestDockerfile(object):
         df.save(filepath.strpath)
         assert len(self.tmpdir.listdir()) == 1, "file not saved"
         assert df.cmd in filepath.read(), "file content not correct"
-
-        with pytest.raises(Exception):
-            df = Dockerfile(self.specs)
-            df.cmd = ""
-            df.save(filepath.strpath)

--- a/neurodocker/tests/test_main.py
+++ b/neurodocker/tests/test_main.py
@@ -73,6 +73,18 @@ def test_convert_args_to_specs():
 
     assert "," not in specs['miniconda']['conda_install']
 
+    args = ['-b', 'ubuntu:17.04', '-p', 'apt',
+            '--ants', 'option']
+    namespace = parse_args(args)
+    with pytest.raises(ValueError):
+        convert_args_to_specs(namespace)
+
+    args = ['-b', 'ubuntu:17.04', '-p', 'apt',
+            '--ants', 'option=']
+    namespace = parse_args(args)
+    with pytest.raises(ValueError):
+        convert_args_to_specs(namespace)
+
 
 def test_main():
     args = ['-b', 'ubuntu:17.04', '-p', 'apt',
@@ -93,16 +105,21 @@ def test_main():
     with pytest.raises(SystemExit):
         main()
 
+    args = ['-b', 'ubuntu:17.04', '-p', 'apt',
+            '--ants', 'option=value']
+    with pytest.raises(ValueError):
+        main(args)
+
 
 def test_no_print(capsys):
     args = ['-b', 'ubuntu:17.04', '-p', 'apt', '--no-check-urls']
     main(args)
-    out, err = capsys.readouterr()
+    out, _ = capsys.readouterr()
     assert "FROM" in out and "RUN" in out
 
     args.append('--no-print-df')
     main(args)
-    out, err = capsys.readouterr()
+    out, _ = capsys.readouterr()
     assert not out
 
 


### PR DESCRIPTION
The following now raise errors:
- `neurodocker -b ubuntu:17.04 -p apt --ants arg1`
- `neurodocker -b ubuntu:17.04 -p apt --ants arg1=`
- `neurodocker -b ubuntu:17.04 -p apt --ants invalidarg=value`