### PR TITLE
enh: add ANTs versions and add params

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Valid options for each software package are the keyword arguments for the class 
 
 ### ANTs
 
-ANTs can be installed using pre-compiled binaries (default behavior), or it can be built from source (takes about 45 minutes). To install ANTs, include `'ants'` (case-insensitive) in the specifications dictionary. Valid options are `'version'` (e.g., `'2.1.0'`) and `'use_binaries'` (if true, use binaries; if false, build from source).
+ANTs can be installed using pre-compiled binaries (default behavior), or it can be built from source (takes about 45 minutes). To install ANTs, include `'ants'` (case-insensitive) in the specifications dictionary. Valid options are `'version'` (e.g., `'2.1.0'`), `'use_binaries'` (if true, use binaries; if false, build from source, if str, must be URL with tarball of binaries that extracts to a directory `ants`), and `'git_hash'` (build from source from specific hash).
+
+Repository with pre-compiled binaries: [kaczmarj/ANTs-builds](https://github.com/kaczmarj/ANTs-builds)
 
 View source: [`neurodocker.interfaces.ANTs`](neurodocker/interfaces/ants.py).
 

--- a/neurodocker/interfaces/ants.py
+++ b/neurodocker/interfaces/ants.py
@@ -62,8 +62,10 @@ class ANTs(object):
                       "2.0.0": "7ae1107c102f7c6bcffa4df0355b90c323fcde92",
                       "HoneyPot": "7ae1107c102f7c6bcffa4df0355b90c323fcde92",}
 
-    VERSION_TARBALLS = {"2.1.0": "https://www.dropbox.com/s/x7eyk125bhwiisu/ants-2.1.0_centos-5.tar.gz?dl=1",
-                        "2.0.3": "https://www.dropbox.com/s/09yd0jbohcwl24z/ants-2.0.3_centos-5.tar.gz?dl=1",}
+    VERSION_TARBALLS = {"2.2.0": "https://www.dropbox.com/s/2f4sui1z6lcgyek/ANTs-Linux-centos5_x86_64-v2.2.0-0740f91.tar.gz?dl=1",
+                        "2.1.0": "https://www.dropbox.com/s/h8k4v6d1xrv0wbe/ANTs-Linux-centos5_x86_64-v2.1.0-78931aa.tar.gz?dl=1",
+                        "2.0.3": "https://www.dropbox.com/s/oe4v52lveyt1ry9/ANTs-Linux-centos5_x86_64-v2.0.3-c996539.tar.gz?dl=1",
+                        "2.0.0": "https://www.dropbox.com/s/kgqydc44cc2uigb/ANTs-Linux-centos5_x86_64-v2.0.0-7ae1107.tar.gz?dl=1",}
 
     def __init__(self, version, pkg_manager, use_binaries=True, git_hash=None,
                  check_urls=True):
@@ -105,7 +107,7 @@ class ANTs(object):
         if self.check_urls:
             check_url(url)
 
-        cmd = ("RUN curl -sSL {} | tar zx -C /opt".format(url))
+        cmd = ("RUN curl -sSL --retry 5 {} | tar zx -C /opt".format(url))
 
         env_cmd = ("ANTSPATH=/opt/ants"
                    "\nPATH=/opt/ants:$PATH")
@@ -121,7 +123,11 @@ class ANTs(object):
                 'yum': 'cmake gcc-c++ git make zlib-devel'}
 
         if self.git_hash is None:
-            self.git_hash = ANTs.VERSION_HASHES[self.version]
+            try:
+                self.git_hash = ANTs.VERSION_HASHES[self.version]
+            except KeyError:
+                raise ValueError("git hash not known for version {}"
+                                 "".format(self.version))
 
         if self.version == "latest":
             checkout = ""

--- a/neurodocker/interfaces/ants.py
+++ b/neurodocker/interfaces/ants.py
@@ -2,24 +2,29 @@
 
 Project repository: https://github.com/stnava/ANTs/
 
-ANTs recommends building from source. Versions 2.0.0 and newer are available
-on GitHub, and older versions are available on SourceForge.
+ANTs recommends building from source. Jakub Kaczmarzyk build several versions
+on CentOS 6 Docker images. Those Docker images are located at
+https://hub.docker.com/r/kaczmarj/ants/ and the binaries are on Dropbox. See
+the ANTs class definition for the Dropbox URLs.
 
-Build from source (takes approximately 40 minutes):
+Source for ANTs versions 2.0.0 and newer are available on GitHub, and older
+versions are available on SourceForge.
+
+Instructions to build from source (takes approximately 40 minutes):
 https://github.com/stnava/ANTs/wiki/Compiling-ANTs-on-Linux-and-Mac-OS
 """
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
+
 from __future__ import absolute_import, division, print_function
-import logging
 
-from neurodocker.utils import indent, manage_pkgs
-
-logger = logging.getLogger(__name__)
+from neurodocker.utils import check_url, indent, manage_pkgs
 
 
 class ANTs(object):
-    """Add Dockerfile instructions to install ANTs. Versions 2.x are
-    supported.
+    """Add Dockerfile instructions to install ANTs. Versions 2.0.0 and newer
+    are supported. Pre-compiled binaries can be downloaded, or ANTs can be
+    built from source. The pre-compiled binaries were compiled on a CentOS 6
+    Docker image. The build log file is present in the ANTs tarball.
 
     Inspired by the Dockerfile at https://hub.docker.com/r/nipype/workshops/
     `docker pull nipype/workshops:latest-nofsspm`
@@ -30,12 +35,20 @@ class ANTs(object):
         ANTs version.
     pkg_manager : {'apt', 'yum'}
         Linux package manager.
-    use_binaries : bool
+    use_binaries : bool, str
         If true, uses pre-compiled ANTs binaries. If false, attempts to build
-        from source.
+        from source. Can also be URL of tarball containing binaries. If this is
+        specified, overrides the default binaries for the specified version.
+        The binaries must be in the folder `ants`, as ANTSPATH=`/opt/ants` and
+        the tarball will be decompressed in /opt. URL must begin with http or
+        ftp.
+    git_hash : str
+        If this is specified and use_binaries is false, build from source from
+        this commit. If this is not specified and use_binaries is false, will
+        use git hash of the specified version.
     check_urls : bool
-        If true, throw warning if a URL used by this class responds with a
-        status code greater than 400.
+        If true, raise error if a URL used by this class responds with a status
+        code greater than 400.
     """
     VERSION_HASHES = {"latest": None,
                       "2.2.0": "0740f9111e5a9cd4768323dc5dfaa7c29481f9ef",
@@ -52,11 +65,12 @@ class ANTs(object):
     VERSION_TARBALLS = {"2.1.0": "https://www.dropbox.com/s/x7eyk125bhwiisu/ants-2.1.0_centos-5.tar.gz?dl=1",
                         "2.0.3": "https://www.dropbox.com/s/09yd0jbohcwl24z/ants-2.0.3_centos-5.tar.gz?dl=1",}
 
-    def __init__(self, version, pkg_manager, use_binaries=True,
+    def __init__(self, version, pkg_manager, use_binaries=True, git_hash=None,
                  check_urls=True):
         self.version = version
         self.pkg_manager = pkg_manager
         self.use_binaries = use_binaries
+        self.git_hash = git_hash
         self.check_urls = check_urls
 
         self.cmd = self._create_cmd()
@@ -66,59 +80,76 @@ class ANTs(object):
         comment = ("#-------------------\n"
                    "# Install ANTs {}\n"
                    "#-------------------".format(self.version))
+
         if self.use_binaries:
             chunks = [comment, self.install_binaries()]
         else:
             chunks = [comment, self.build_from_source_github()]
+
         return "\n".join(chunks)
 
     def install_binaries(self):
-        try:
-            url = ANTs.VERSION_TARBALLS[self.version]
-        except KeyError:
-            raise ValueError("No tarball for version {}".format(self.version))
+        """Return command to download and install ANTs binaries. Supports
+        custom URL with tarball of binaries.
+        """
+        bin_str = str(self.use_binaries)
+        if bin_str.startswith("http") or bin_str.startswith("ftp"):
+            url = self.use_binaries
+        else:
+            try:
+                url = ANTs.VERSION_TARBALLS[self.version]
+            except KeyError:
+                raise ValueError("Tarball not available for version {}."
+                                 "".format(self.version))
 
-        workdir_cmd = "WORKDIR /opt"
-        cmd = ("URL={url}\n"
-               "&& curl -sSL $URL | tar zx\n".format(url=url))
-        cmd = indent("RUN", cmd)
-        # Requires two ENV instructions because the second uses one defined in
-        # the first.
-        env_cmd = ("ANTSPATH=/opt/ants\n"
-                   "PATH=/opt/ants:$PATH")
+        if self.check_urls:
+            check_url(url)
+
+        cmd = ("RUN curl -sSL {} | tar zx -C /opt".format(url))
+
+        env_cmd = ("ANTSPATH=/opt/ants"
+                   "\nPATH=/opt/ants:$PATH")
         env_cmd = indent("ENV", env_cmd)
-        return "\n".join((workdir_cmd, cmd, env_cmd))
+
+        return "\n".join((cmd, env_cmd))
 
     def build_from_source_github(self):
-        """Return Dockerfile instructions to build ANTs from source."""
+        """Return Dockerfile instructions to build ANTs from source. Checkout
+        to commit based on git_hash or version. If 'latest', build from master.
+        """
         pkgs = {'apt': 'cmake g++ gcc git make zlib1g-dev',
                 'yum': 'cmake gcc-c++ git make zlib-devel'}
+
+        if self.git_hash is None:
+            self.git_hash = ANTs.VERSION_HASHES[self.version]
 
         if self.version == "latest":
             checkout = ""
         else:
-            version_hash = ANTs.VERSION_HASHES[self.version]
-            checkout = "&& git checkout {}\n".format(version_hash)
+            checkout = ("\n&& cd ANTs"
+                        "\n&& git checkout {}"
+                        "\n&& cd .."
+                        "".format(self.git_hash))
 
         workdir_cmd = "WORKDIR /tmp/ants-build"
-        cmd = ("deps='{pkgs}'\n"
-               "&& {install}\n"
-               "&& {clean}\n"
-               "&& git clone https://github.com/stnava/ANTs.git\n"
-               "&& cd ANTs\n"
+        cmd = ("deps='{pkgs}'"
+               "\n&& {install}"
+               "\n&& {clean}"
+               "\n&& git clone https://github.com/stnava/ANTs.git"
                "{checkout}"
-               "&& cd .. && mkdir build && cd build\n"
-               "&& cmake ../ANTs && make -j 2\n"
-               "&& mkdir -p /opt/ants\n"
-               "&& mv bin/* /opt/ants && mv ../ANTs/Scripts/* /opt/ants\n"
-               "&& cd /tmp && rm -rf ants-build\n"
-               "&& {remove}"
+               "\n&& mkdir build && cd build"
+               "\n&& cmake ../ANTs && make -j 1"
+               "\n&& mkdir -p /opt/ants"
+               "\n&& mv bin/* /opt/ants && mv ../ANTs/Scripts/* /opt/ants"
+               "\n&& rm -rf /tmp/*"
+               "\n&& {remove}"
                "".format(pkgs=pkgs[self.pkg_manager], checkout=checkout,
                          **manage_pkgs[self.pkg_manager]))
         cmd = cmd.format(pkgs='$deps')
         cmd = indent("RUN", cmd)
 
-        env_cmd = ("ENV ANTSPATH=/opt/ants\n"
-                   "ENV PATH=$ANTSPATH:$PATH")
+        env_cmd = ("ANTSPATH=/opt/ants\n"
+                   "PATH=/opt/ants:$PATH")
+        env_cmd = indent("ENV", env_cmd)
 
         return "\n".join((workdir_cmd, cmd, env_cmd))

--- a/neurodocker/interfaces/tests/test_ants.py
+++ b/neurodocker/interfaces/tests/test_ants.py
@@ -28,14 +28,10 @@ class TestANTs(object):
             ANTs(version='fakeversion', pkg_manager='apt', check_urls=False)
 
     def test_install_with_custom_url(self):
-        url = 'http://fakesite'
+        url = 'http://fakesite.com'
         ants = ANTs(version='2.2.0', pkg_manager='apt', use_binaries=url,
                     check_urls=False)
         assert url in ants.cmd
-
-        with pytest.raises(ValueError):
-            ants = ANTs(version='2.2.0', pkg_manager='apt',
-                        use_binaries='fakesite', check_urls=False)
 
     def test_build_from_source_github(self):
         # TODO: expand on tests for building ANTs from source. It probably

--- a/neurodocker/interfaces/tests/test_ants.py
+++ b/neurodocker/interfaces/tests/test_ants.py
@@ -1,6 +1,9 @@
 """Tests for neurodocker.interfaces.ANTs"""
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
+
 from __future__ import absolute_import, division, print_function
+
+import pytest
 
 from neurodocker.interfaces import ANTs
 from neurodocker.interfaces.tests import utils
@@ -13,12 +16,26 @@ class TestANTs(object):
         """Install ANTs 2.1.0 binaries on CentOS 7."""
         specs = {'base': 'centos:7',
                  'pkg_manager': 'yum',
-                 'check_urls': False,
+                 'check_urls': True,
                  'ants': {'version': '2.1.0', 'use_binaries': True}}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('Atropos')
         assert "error" not in output, "error running Atropos"
         utils.test_cleanup(container)
+
+    def test_invalid_binaries(self):
+        with pytest.raises(ValueError):
+            ANTs(version='fakeversion', pkg_manager='apt', check_urls=False)
+
+    def test_install_with_custom_url(self):
+        url = 'http://fakesite'
+        ants = ANTs(version='2.2.0', pkg_manager='apt', use_binaries=url,
+                    check_urls=False)
+        assert url in ants.cmd
+
+        with pytest.raises(ValueError):
+            ants = ANTs(version='2.2.0', pkg_manager='apt',
+                        use_binaries='fakesite', check_urls=False)
 
     def test_build_from_source_github(self):
         # TODO: expand on tests for building ANTs from source. It probably
@@ -26,7 +43,11 @@ class TestANTs(object):
         # time limit. It takes about 45 minutes to compile ANTs.
 
         ants = ANTs(version='latest', pkg_manager='apt', use_binaries=False)
+        assert "git checkout" not in ants.cmd
+
+        ants = ANTs(version='2.2.0', pkg_manager='yum', use_binaries=False)
         assert ants.cmd
 
-        ants = ANTs(version='latest', pkg_manager='yum', use_binaries=False)
-        assert ants.cmd
+        ants = ANTs(version='arbitrary', pkg_manager='apt', use_binaries=False,
+                    git_hash='12345')
+        assert 'git checkout 12345' in ants.cmd

--- a/neurodocker/main.py
+++ b/neurodocker/main.py
@@ -36,10 +36,12 @@ def create_parser():
                 "key=value pairs.\nWhere applicable, the default installation "
                 "behavior is to install by\ndownloading and uncompressing "
                 "binaries."),
-        "ants": ("Install ANTs. Valid keys are version (required) and "
-                "use_binaries (default true). If use_binaries=true, installs "
-                "pre-compiled binaries; if use_binaries=false, builds ANTs "
-                "from source."),
+        "ants": ("Install ANTs. Valid keys are version (required), "
+                "use_binaries (default true), and git_hash. If use_binaries="
+                "true, installs pre-compiled binaries; if use_binaries=false, "
+                "builds ANTs from source. If use_binaries is a URL, download "
+                "tarball of ANTs binaries from that URL. If git_hash is "
+                "specified, build from source from that commit."),
         "fsl": ("Install FSL. Valid keys are version (required), use_binaries "
                 "(default true), use_installer, use_neurodebian, and "
                 "os_codename (eg, jessie)."),


### PR DESCRIPTION
Users can provide their own URL with ANTs binaries and can specify a commit from which to build.

Available binaries:

- 2.2.0
- 2.1.0
- 2.0.3
- 2.0.0

See [kaczmarj/ANTs-builds](https://github.com/kaczmarj/ANTs-builds) for more info.