### PR TITLE
enh: add mrtrix3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - INTERFACE_TO_BUILD=ants
   - INTERFACE_TO_BUILD=fsl
   - INTERFACE_TO_BUILD=miniconda
+  - INTERFACE_TO_BUILD=mrtrix3
   - INTERFACE_TO_BUILD=spm
 before_install:
   - travis_retry sudo apt-get update && sudo apt-get install -yq docker-engine

--- a/neurodocker/__init__.py
+++ b/neurodocker/__init__.py
@@ -2,12 +2,13 @@
 
 from __future__ import absolute_import
 
-from neurodocker.interfaces import ANTs, FSL, Miniconda, SPM
+from neurodocker import interfaces
 
-SUPPORTED_SOFTWARE = {'ants': ANTs,
-                      'fsl': FSL,
-                      'miniconda': Miniconda,
-                      'spm': SPM,
+SUPPORTED_SOFTWARE = {'ants': interfaces.ANTs,
+                      'fsl': interfaces.FSL,
+                      'miniconda': interfaces.Miniconda,
+                      'mrtrix3': interfaces.MRtrix3,
+                      'spm': interfaces.SPM,
                       }
 
 from neurodocker.dockerfile import Dockerfile

--- a/neurodocker/interfaces/__init__.py
+++ b/neurodocker/interfaces/__init__.py
@@ -3,4 +3,5 @@ from __future__ import absolute_import
 from neurodocker.interfaces.ants import ANTs
 from neurodocker.interfaces.fsl import FSL
 from neurodocker.interfaces.miniconda import Miniconda
+from neurodocker.interfaces.mrtrix import MRtrix3
 from neurodocker.interfaces.spm import SPM

--- a/neurodocker/interfaces/mrtrix.py
+++ b/neurodocker/interfaces/mrtrix.py
@@ -1,5 +1,10 @@
 """Add Dockerfile instructions to install MRtrix.
 
+MRtrix GitHub repository: https://github.com/MRtrix3/mrtrix3
+
+MRtrix recommends building from source. Binaries for MRtrix3 were compiled on
+CentOS 6.6 and uploaded to Dropbox. This file uses those binaries if the user
+wants to use pre-compiled binaries.
 """
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
 
@@ -9,10 +14,9 @@ from neurodocker.utils import check_url, indent, manage_pkgs
 
 
 class MRtrix3(object):
-    """Add Dockerfile instructions to install MRtrix. Version 3 is supported.
-    Pre-compiled binaries can be downloaded, or MRtrix can be
-    built from source. The pre-compiled binaries were compiled on a CentOS 6.6
-    Docker image.
+    """Add Dockerfile instructions to install MRtrix3. Pre-compiled binaries
+    can be downloaded, or MRtrix can be built from source. The pre-compiled
+    binaries were compiled on a CentOS 6.6 Docker image.
 
     Parameters
     ----------
@@ -37,7 +41,7 @@ class MRtrix3(object):
         self.check_urls = check_urls
 
         if not self.use_binaries and self.pkg_manager == "yum":
-            raise ValueError("Building MRtrix on CentOS/Fedora is not "
+            raise ValueError("Building MRtrix3 on CentOS/Fedora is not "
                              "supported yet.")
 
         self.cmd = self._create_cmd()

--- a/neurodocker/interfaces/mrtrix.py
+++ b/neurodocker/interfaces/mrtrix.py
@@ -1,0 +1,102 @@
+"""Add Dockerfile instructions to install MRtrix.
+
+"""
+# Author: Jakub Kaczmarzyk <jakubk@mit.edu>
+
+from __future__ import absolute_import, division, print_function
+
+from neurodocker.utils import check_url, indent, manage_pkgs
+
+
+class MRtrix3(object):
+    """Add Dockerfile instructions to install MRtrix. Version 3 is supported.
+    Pre-compiled binaries can be downloaded, or MRtrix can be
+    built from source. The pre-compiled binaries were compiled on a CentOS 6.6
+    Docker image.
+
+    Parameters
+    ----------
+    pkg_manager : {'apt', 'yum'}
+        Linux package manager.
+    use_binaries : bool, str
+        If true, uses pre-compiled MRtrix3 binaries. If false, attempts to
+        build from source (with -nogui option).
+    git_hash : str
+        If this is specified and use_binaries is false, checkout to this commit
+        before building.
+    check_urls : bool
+        If true, raise error if a URL used by this class responds with a status
+        code greater than 400.
+    """
+
+    def __init__(self, pkg_manager, use_binaries=True, git_hash=None,
+                 check_urls=True):
+        self.pkg_manager = pkg_manager
+        self.use_binaries = use_binaries
+        self.git_hash = git_hash
+        self.check_urls = check_urls
+
+        if not self.use_binaries and self.pkg_manager == "yum":
+            raise ValueError("Building MRtrix on CentOS/Fedora is not "
+                             "supported yet.")
+
+        self.cmd = self._create_cmd()
+
+    def _create_cmd(self):
+        """Return full command to install MRtrix."""
+        comment = ("#----------------\n"
+                   "# Install MRtrix3\n"
+                   "#----------------")
+
+        if self.use_binaries:
+            chunks = [comment, self.install_binaries()]
+        else:
+            chunks = [comment, self.build_from_source()]
+
+        return "\n".join(chunks)
+
+    def install_binaries(self):
+        """Return command to download and install MRtrix3 binaries."""
+        url = ("https://www.dropbox.com/s/2g008aaaeht3m45/"
+               "mrtrix3-Linux-centos6.tar.gz?dl=0")
+
+        if self.check_urls:
+            check_url(url)
+
+        cmd = ('RUN curl -sSL --retry 5 {} | tar zx -C /opt'.format(url))
+        env_cmd = ("ENV PATH=/opt/mrtrix3/bin:$PATH")
+
+        return "\n".join((cmd, env_cmd))
+
+    def build_from_source(self):
+        """Return Dockerfile instructions to build MRtrix from source. Checkout
+        to git_hash if specified.
+        """
+        # QUESTION: how to download eigen3-devel? Have to add EPEL.
+        pkgs = {'apt': 'g++ git libeigen3-dev zlib1g-dev',
+                'yum': 'eigen3-devel gcc-c++ git zlib-devel'}
+
+        if self.git_hash == None:
+            checkout = ""
+        else:
+            checkout = ("\n&& git checkout {}".format(self.git_hash))
+
+        workdir_cmd = "WORKDIR /opt"
+        cmd = ("deps='{pkgs}'"
+               "\n&& {install}"
+               "\n&& {clean}"
+               "\n&& git clone https://github.com/MRtrix3/mrtrix3.git"
+               "\n&& cd mrtrix3"
+               "{checkout}"
+               "\n&& ./configure -nogui"
+               "\n&& ./build"
+               "\n&& rm -rf tmp/* /tmp/*"
+               "\n&& {remove}"
+               "".format(pkgs=pkgs[self.pkg_manager], checkout=checkout,
+                         **manage_pkgs[self.pkg_manager]))
+        cmd = cmd.format(pkgs='$deps')
+        cmd = indent("RUN", cmd)
+
+        env_cmd = ("ENV PATH=/opt/mrtrix3/bin:$PATH")
+
+        return "\n".join((workdir_cmd, cmd, env_cmd))

--- a/neurodocker/interfaces/tests/test_mrtrix.py
+++ b/neurodocker/interfaces/tests/test_mrtrix.py
@@ -1,0 +1,37 @@
+"""Tests for neurodocker.interfaces.ANTs"""
+# Author: Jakub Kaczmarzyk <jakubk@mit.edu>
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from neurodocker.interfaces import MRtrix3
+from neurodocker.interfaces.tests import utils
+
+
+class TestMRtrix3(object):
+    """Tests for MRtrix3 class."""
+
+    def test_build_image_mrtrix3_binaries_centos7(self):
+        """Install MRtrix3 binaries on CentOS 7."""
+        specs = {'base': 'centos:7',
+                 'pkg_manager': 'yum',
+                 'check_urls': True,
+                 'mrtrix3': {'use_binaries': True}}
+        container = utils.get_container_from_specs(specs)
+        output = container.exec_run('mrinfo')
+        assert "error" not in output, "error running mrinfo"
+        utils.test_cleanup(container)
+
+    def test_build_from_source(self):
+        # TODO: expand on tests for building MRtrix from source.
+
+        mrtrix = MRtrix3(pkg_manager='apt', use_binaries=False)
+        assert "git checkout" not in mrtrix.cmd
+
+        with pytest.raises(ValueError):
+            MRtrix3(pkg_manager='yum', use_binaries=False)
+
+        mrtrix = MRtrix3(pkg_manager='apt', use_binaries=False,
+                         git_hash='12345')
+        assert 'git checkout 12345' in mrtrix.cmd

--- a/neurodocker/main.py
+++ b/neurodocker/main.py
@@ -55,6 +55,10 @@ def create_parser():
                       "conda_install and pip_install take an arbitrary number "
                       "of comma-separated values (no white-space). "
                       "Example: conda_install=pandas,pytest,traits)."),
+        "mrtrix3" : ("Install MRtrix3. Valid keys are use_binaries (default "
+                     "true) and git_hash. If git_hash is specified and "
+                     "use_binaries is false, will checkout to that commit "
+                     "before building."),
         "spm": ("Install SPM (and its dependency, Matlab Compiler Runtime). "
                 "Valid keys are version and matlab_version."),
     }
@@ -66,6 +70,13 @@ def create_parser():
 
     for p in SUPPORTED_SOFTWARE.keys():
         flag = "--{}".format(p)
+
+        # MRtrix3 does not need any arguments by default.
+        if p == "mrtrix3":
+            pkgs.add_argument(flag, dest=p, action="append", nargs="*",
+                              metavar="", type=list_of_kv, help=pkgs_help[p])
+            continue
+
         pkgs.add_argument(flag, dest=p, action="append", nargs="+", metavar="",
                           type=list_of_kv, help=pkgs_help[p])
 

--- a/neurodocker/tests/test_main.py
+++ b/neurodocker/tests/test_main.py
@@ -63,6 +63,7 @@ def test_convert_args_to_specs():
             '--ants', 'version=2.1.0',
             '--fsl', 'version=5.0.10',
             '--miniconda', 'conda_install=pandas,traits',
+            '--mrtrix3',
             '--spm', 'version=12',
             '--no-check-urls']
     namespace = parse_args(args)
@@ -91,6 +92,7 @@ def test_main():
             '--ants', 'version=2.1.0',
             '--fsl', 'version=5.0.10',
             '--miniconda', 'python_version=3.5.1',
+            '--mrtrix3',
             '--spm', 'version=12', 'matlab_version=R2017a',
             '--no-check-urls']
     main(args)


### PR DESCRIPTION
Add support for installing MRtrix3 from binaries or building from source. Neurodocker does not yet support building MRtrix3 from source on systems that use `yum` because the package `eigen3-devel` is required but is not in the base repositories. Another repository (e.g., EPEL) will have to be added, but I'm not sure how to do this in a way that is agnostic of OS version.

[MRtrix3 project repository](https://github.com/MRtrix3/mrtrix3)