### PR TITLE
FIX: source fsl.sh instead of copying to profile.d

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
+sudo: required
+dist: trusty
+group: edge
+
+services:
+  - docker
 language: python
 python:
   # - 2.7
@@ -5,9 +11,7 @@ python:
 branches:
   only:
     - master
-sudo: required
-services:
-  - docker
+
 env:
   - INTERFACE_TO_BUILD=none
   - INTERFACE_TO_BUILD=ants
@@ -15,8 +19,6 @@ env:
   - INTERFACE_TO_BUILD=miniconda
   - INTERFACE_TO_BUILD=mrtrix3
   - INTERFACE_TO_BUILD=spm
-before_install:
-  - travis_retry sudo apt-get update && sudo apt-get install -yq docker-engine
 install:
   - travis_retry pip install -r requirements.txt
   - travis_retry pip install pytest-cov

--- a/neurodocker/interfaces/fsl.py
+++ b/neurodocker/interfaces/fsl.py
@@ -95,10 +95,10 @@ class FSL(object):
         url = "https://fsl.fmrib.ox.ac.uk/fsldownloads/fslinstaller.py"
         if check_urls:
             check_url(url)
-        cmd = ("curl -sSL -o fslinstaller.py {url}\n"
-               "&& python fslinstaller.py --dest=/opt --quiet\n"
-               "&& cp /opt/fsl/etc/fslconf/fsl.sh /etc/profile.d/\n"
-               "&& rm -f fslinstaller.py"
+        cmd = ("curl -sSL -o fslinstaller.py {url}"
+               "\n&& python fslinstaller.py --dest=/opt --quiet"
+               "\n&& . /opt/fsl/etc/fslconf/fsl.sh"
+               "\n&& rm -f fslinstaller.py"
                "".format(url=url))
         cmd = indent("RUN", cmd)
 
@@ -125,7 +125,7 @@ class FSL(object):
         on FSL's website."""
         cmd = ('curl -sSL {url}'
                '\n| tar zx -C /opt'
-               '\n&& cp /opt/fsl/etc/fslconf/fsl.sh /etc/profile.d/'
+               '\n&& . /opt/fsl/etc/fslconf/fsl.sh'
                '\n&& FSLPYFILE=/opt/fsl/etc/fslconf/fslpython_install.sh'
                '\n&& [ -f $FSLPYFILE ] && $FSLPYFILE -f /opt/fsl -q || true'
                ''.format(url=url))


### PR DESCRIPTION
Fixes a bug where `fsl.sh` was not being sourced. The file `fsl.sh` was being copied to the directory `/etc/profile.d` but those files are only sourced when logging in. Starting up a Docker container in the does not login by default, so those files would not be sourced.

See https://stackoverflow.com/a/38025686/5666087