### PR TITLE
ADD: feature to supply arbitrary dockerfile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ specs = {
     'ants': {'version': '2.2.0', 'use_binaries': True},
     'fsl': {'version': '5.0.10', 'use_binaries': True},
     'spm': {'version': '12', 'matlab_version': 'R2017a'},
-    'instruction': ['RUN echo "Hello, World"' 'ENTRYPOINT ["run.sh"]']
+    'instruction': ['RUN echo "Hello, World"',
+                    'ENTRYPOINT ["run.sh"]']
 }
 
 parser = SpecsParser(specs)

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ docker run --rm kaczmarj/neurodocker -b ubuntu:17.04 -p apt \
 
 ## Command-line example
 
-Generate Dockerfile, do not print result to stdout, save to file. Build the Docker image with `docker build`.
+Generate Dockerfile, do not print result to stdout, save to file. Build the Docker image with `docker build`. Arbitrary Dockerfile instructions can be added to the end of the Dockerfile.
 
 Example:
 
@@ -96,6 +96,7 @@ neurodocker -b centos:7 -p yum \
 --miniconda python_version=3.5.1 conda_install=traits,pandas pip_install=nipype \
 --mrtrix3 \
 --spm version=12 matlab_version=R2017a \
+--instruction='ENTRYPOINT ["run.sh"]'
 --no-check-urls --no-print-df -o path/to/project/Dockerfile
 
 # Build Docker image using the saved Dockerfile.
@@ -144,7 +145,7 @@ container.cleanup(remove=True)
 
 ## Full scripting example
 
-This example creates a Dockerfile with all of the software that _Neurodocker_ supports.
+This example creates a Dockerfile with all of the software that _Neurodocker_ supports and with arbitrary, user-defined Dockerfile instructions.
 
 ```python
 from neurodocker import Dockerfile, SpecsParser
@@ -162,6 +163,7 @@ specs = {
     'ants': {'version': '2.2.0', 'use_binaries': True},
     'fsl': {'version': '5.0.10', 'use_binaries': True},
     'spm': {'version': '12', 'matlab_version': 'R2017a'},
+    'instruction': ['RUN echo "Hello, World"' 'ENTRYPOINT ["run.sh"]']
 }
 
 parser = SpecsParser(specs)
@@ -258,4 +260,13 @@ ENV MATLABCMD=/opt/mcr/v*/toolbox/matlab \
     SPMMCRCMD="/opt/spm*/run_spm*.sh /opt/mcr/v*/ script" \
     FORCE_SPMMCR=1 \
     LD_LIBRARY_PATH=/opt/mcr/v*/runtime/glnxa64:/opt/mcr/v*/bin/glnxa64:/opt/mcr/v*/sys/os/glnxa64:$LD_LIBRARY_PATH
+
+
+#--------------------------
+# User-defined instructions
+#--------------------------
+
+RUN echo "Hello, World"
+
+ENTRYPOINT ["run.sh"]
 ```

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -66,8 +66,7 @@ class Dockerfile(object):
             comment = ("\n#--------------------------"
                        "\n# User-defined instructions"
                        "\n#--------------------------")
-            cmds.append(comment)
-            cmds.extend(self.specs['instruction'])
+            cmds.extend((comment, *self.specs['instruction']))
         except KeyError:
             pass
 

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -61,6 +61,16 @@ class Dockerfile(object):
         if software_cmds:
             cmds.append(software_cmds)
 
+        # Add arbitrary Dockerfile instructions.
+        try:
+            comment = ("\n#--------------------------"
+                       "\n# User-defined instructions"
+                       "\n#--------------------------")
+            cmds.append(comment)
+            cmds.extend(self.specs['instruction'])
+        except KeyError:
+            pass
+
         return "\n\n".join(cmds) + "\n"
 
     def add_base(self):

--- a/neurodocker/main.py
+++ b/neurodocker/main.py
@@ -11,7 +11,9 @@ Example:
                 conda_install=traits,pandas \
                 pip_install=nipype \
     --mrtrix3 use_binaries=false \
-    --spm version=12 matlab_version=R2017a
+    --spm version=12 matlab_version=R2017a \
+    --instruction='RUN echo "Hello, World!"' \
+    --instruction='ENTRYPOINT ["entrypoint.sh"]'
 """
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
 
@@ -84,6 +86,9 @@ def create_parser():
 
     # Docker-related arguments.
     dkr = parser.add_argument_group(title="Docker-related arguments")
+    dkr.add_argument('-i', '--instruction', action="append",
+                     help=("Arbitrary Dockerfile instruction. Can be used "
+                           "multiple times."))
     dkr.add_argument('--no-print-df', dest='no_print_df', action="store_true",
                      help="Do not print the Dockerfile")
     dkr.add_argument('-o', '--output', dest="output",

--- a/neurodocker/parser.py
+++ b/neurodocker/parser.py
@@ -18,7 +18,7 @@ class SpecsParser(object):
         The dictionary of specifications, or the name of the JSON file with the
         specifications.
     """
-    VALID_TOP_LEVEL_KEYS = ['base', 'pkg_manager', 'check_urls']
+    VALID_TOP_LEVEL_KEYS = ['base', 'pkg_manager', 'check_urls', 'instruction']
     VALID_TOP_LEVEL_KEYS.extend(SUPPORTED_SOFTWARE.keys())
 
     def __init__(self, dict_or_filepath):

--- a/neurodocker/tests/test_dockerfile.py
+++ b/neurodocker/tests/test_dockerfile.py
@@ -22,7 +22,8 @@ class TestDockerfile(object):
                                     'pip_install': 'pandas'},
                       'ants': {'version': '2.1.0', 'use_binaries': True},
                       'fsl': {'version': '5.0.10', 'use_binaries': True},
-                      'spm': {'version': 12, 'matlab_version': 'R2017a'},}
+                      'spm': {'version': 12, 'matlab_version': 'R2017a'},
+                      'instruction': ['RUN ls', 'WORKDIR /home'],}
 
         self.base = "FROM {}".format(self.specs['base'])
         self.noninteractive = "ARG DEBIAN_FRONTEND=noninteractive"
@@ -46,6 +47,8 @@ class TestDockerfile(object):
         assert self.ants in cmd
         assert self.fsl in cmd
         assert self.spm in cmd
+        assert self.specs['instruction'][0] in cmd
+        assert self.specs['instruction'][1] in cmd
 
     def test_add_base(self):
         assert "FROM" in Dockerfile(self.specs).add_base()

--- a/neurodocker/tests/test_main.py
+++ b/neurodocker/tests/test_main.py
@@ -52,6 +52,11 @@ def test_parse_args():
     namespace = parse_args(args)
     assert namespace.spm
 
+    args = base_args + ['--instruction', 'RUN ls']
+    namespace = parse_args(args)
+    assert namespace.instruction
+    assert isinstance(namespace.instruction, list)
+
     args = base_args + ['--no-check-urls']
     namespace = parse_args(args)
     assert not namespace.check_urls
@@ -64,6 +69,8 @@ def test_convert_args_to_specs():
             '--miniconda', 'conda_install=pandas,traits',
             '--mrtrix3',
             '--spm', 'version=12',
+            '--instruction', 'RUN ls',
+            '--instruction', 'WORKDIR /home',
             '--no-check-urls']
     namespace = parse_args(args)
     assert namespace


### PR DESCRIPTION
This PR adds a feature that allows the user to include arbitrary Dockerfile instructions. Those instructions are always added at the end of the Dockerfile and are included in the order they were given.

Closes #19 