### PR TITLE
ADD: AFNI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ branches:
 
 env:
   - INTERFACE_TO_BUILD=none
+  - INTERFACE_TO_BUILD=afni
   - INTERFACE_TO_BUILD=ants
   - INTERFACE_TO_BUILD=fsl
   - INTERFACE_TO_BUILD=miniconda

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Note that building and minifying Docker images is not possible with the _Neurodo
 
 Valid options for each software package are the keyword arguments for the class that installs that package. These classes live in [`neurodocker.interfaces`](neurodocker/interfaces/). The default installation behavior for every software package (except Miniconda) is to install by downloading and un-compressing the binaries.
 
+
+## AFNI
+
+AFNI can only be installed using pre-compiled binaries (compiling from source might come in a future update). To install AFNI, include `'afni'` (case-insensitive) in the specifications dictionary. The only valid option is `'version'` (either 'latest' or '17.2.02' at this time).
+
+View source: [`neurodocker.interfaces.AFNI`](neurodocker/interfaces/afni.py)
+
+
 ## ANTs
 
 ANTs can be installed using pre-compiled binaries (default behavior), or it can be compiled from source (takes about 45 minutes). To install ANTs, include `'ants'` (case-insensitive) in the specifications dictionary. Valid options are `'version'` (e.g., `'2.2.0'`), `'use_binaries'` (if true, use binaries; if false, compiles from source), and `'git_hash'` (checks out to specific hash before compiling). If `'version'` is latest and `'use_binaries'` is false, builds master branch from source. To install ANTs from NeuroDebian, see the [NeuroDebian interface](#neurodebian).

--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ Examples:
     - [Generate Dockerfile (without project's Docker image)](#generate-dockerfile-without-projects-docker-image)
   - In a Python script
     - [Generate Dockerfile, build Docker image, run commands in image (minimal)](#generate-dockerfile-build-docker-image-run-commands-in-image-minimal)
-    - [Generate Dockerfile, build Docker image, run commands in image (full)](#generate-dockerfile-build-docker-image-run-commands-in-image-full)
+    - [Generate full Dockerfile](#generate-full-dockerfile)
       - [Generated Dockerfile](examples/generated-full.Dockerfile)
   - "Minify" Docker image
     - [Minify existing Docker image](#minify-existing-docker-image)
+    - [Example of minimizing Docker image for FreeSurfer recon-all](https://github.com/freesurfer/freesurfer/issues/70#issuecomment-316361886)
 
 
 # Note to users
@@ -121,6 +122,7 @@ In this example, a Dockerfile is generated with all of the software that _Neurod
 ```shell
 # Generate Dockerfile.
 neurodocker generate -b debian:jessie -p yum \
+--afni version=latest \
 --ants version=2.1.0 \
 --freesurfer version=6.0.0 \
 --fsl version=5.0.10 \
@@ -170,13 +172,12 @@ container.cleanup(remove=True)
 ```
 
 
-## Generate Dockerfile, build Docker image, run commands in image (full)
+## Generate full Dockerfile
 
 In this example, we create a Dockerfile with all of the software that _Neurodocker_ supports, and we supply arbitrary Dockerfile instructions.
 
 ```python
 from neurodocker import Dockerfile, SpecsParser
-from neurodocker.docker import DockerImage, DockerContainer
 
 specs = {
     'base': 'ubuntu:17.04',
@@ -186,7 +187,8 @@ specs = {
         'python_version': '3.5.1',
         'conda_install': 'traits',
         'pip_install': 'https://github.com/nipy/nipype/archive/master.tar.gz'},
-    'ants': {'version': '2.2.0', 'use_binaries': True},
+    'afni': {'version': 'latest'},
+    'ants': {'version': '2.2.0'},
     'freesurfer': {'version': '6.0.0', 'license_path': 'rel/path/license.txt'},
     'fsl': {'version': '5.0.10', 'use_binaries': True},
     'mrtrix3': {'use_binaries': False},
@@ -194,7 +196,7 @@ specs = {
                     'pkgs': ['afni', 'dcm2niix']},
     'spm': {'version': '12', 'matlab_version': 'R2017a'},
     'instruction': ['RUN echo "Hello, World"',
-                    'ENTRYPOINT ["run.sh"]']
+                    'ENTRYPOINT ["python"]']
 }
 
 parser = SpecsParser(specs)

--- a/examples/generated-full.Dockerfile
+++ b/examples/generated-full.Dockerfile
@@ -26,6 +26,27 @@ RUN echo "Downloading Miniconda installer ..." \
     	https://github.com/nipy/nipype/archive/master.tar.gz \
     && rm -rf /opt/miniconda/[!envs]*
 
+#--------------------
+# Install AFNI latest
+#--------------------
+RUN apt-get update -qq && apt-get install -yq --no-install-recommends gsl-bin libglu1-mesa-dev libglib2.0-0 libglw1-mesa libgomp1 \
+    libjpeg62 libxm4 netpbm tcsh xfonts-base xvfb \
+    && ln /usr/lib/x86_64-linux-gnu/libgsl.so.19 /usr/lib/x86_64-linux-gnu/libgsl.so.0 \
+    || true \
+    && apt-get install -yq libxp6 \
+    || /bin/bash -c " \
+       curl -o /tmp/libxp6.deb -sSL http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb \
+       && dpkg -i /tmp/libxp6.deb && rm -f /tmp/libxp6.deb" \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && echo "Downloading AFNI ..." \
+    && mkdir -p /opt/afni \
+    && curl -sSL --retry 5 https://afni.nimh.nih.gov/pub/dist/tgz/linux_openmp_64.tgz \
+    | tar zx -C /opt/afni --strip-components=1 \
+    && cp /opt/afni/AFNI.afnirc $HOME/.afnirc \
+    && cp /opt/afni/AFNI.sumarc $HOME/.sumarc
+ENV PATH=/opt/afni:$PATH
+
 #-------------------
 # Install ANTs 2.2.0
 #-------------------
@@ -161,4 +182,4 @@ ENV MATLABCMD=/opt/mcr/v*/toolbox/matlab \
 
 RUN echo "Hello, World"
 
-ENTRYPOINT ["run.sh"]
+ENTRYPOINT ["python"]

--- a/neurodocker/__init__.py
+++ b/neurodocker/__init__.py
@@ -12,7 +12,8 @@ logging.basicConfig(stream=sys.stdout, datefmt='%H:%M:%S', level=logging.INFO,
 
 from neurodocker import interfaces
 
-SUPPORTED_SOFTWARE = {'ants': interfaces.ANTs,
+SUPPORTED_SOFTWARE = {'afni': interfaces.AFNI,
+                      'ants': interfaces.ANTs,
                       'freesurfer': interfaces.FreeSurfer,
                       'fsl': interfaces.FSL,
                       'miniconda': interfaces.Miniconda,

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -81,6 +81,9 @@ class Dockerfile(object):
         software packages.
         """
         deps = "bzip2 ca-certificates curl unzip"
+        if self.pkg_manager == "yum":
+            deps += "epel-release"
+
         comment = ("#----------------------------\n"
                    "# Install common dependencies\n"
                    "#----------------------------")

--- a/neurodocker/interfaces/__init__.py
+++ b/neurodocker/interfaces/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from neurodocker.interfaces.afni import AFNI
 from neurodocker.interfaces.ants import ANTs
 from neurodocker.interfaces.freesurfer import FreeSurfer
 from neurodocker.interfaces.fsl import FSL

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -105,13 +105,14 @@ class AFNI(object):
                     '\n   && dpkg -i /tmp/libxp6.deb && rm -f /tmp/libxp6.deb"'
                     ''.format(deb_url))
 
-        cmd += ('\n&& echo "Downloading AFNI ..."'
+        cmd += ("\n&& {clean}"
+                '\n&& echo "Downloading AFNI ..."'
                 "\n&& mkdir -p /opt/afni"
                 "\n&& curl -sSL --retry 5 {}"
                 "\n| tar zx -C /opt/afni --strip-components=1"
                 "\n&& cp /opt/afni/AFNI.afnirc $HOME/.afnirc"
                 "\n&& cp /opt/afni/AFNI.sumarc $HOME/.sumarc"
-                "\n&& {clean}".format(url, **manage_pkgs[self.pkg_manager]))
+                "".format(url, **manage_pkgs[self.pkg_manager]))
         cmd = indent("RUN", cmd)
 
         env_cmd = "PATH=/opt/afni:$PATH"

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -6,8 +6,9 @@ Documentation: https://afni.nimh.nih.gov/pub/dist/doc/htmldoc/index.html
 
 Notes
 -----
-- AFNI uses semantic versioning starting from 15.3.00, released on GitHub on
-  January 4, 2016. Before this, it is unclear how AFNI was versioned.
+- AFNI uses something like semantic versioning starting from 15.3.00, released
+  on GitHub on January 4, 2016. Before this, it is unclear how AFNI was
+  versioned.
 - Only the latest binaries exist on AFNI's website.
 """
 # Author: Jakub Kaczmarzyk <jakubk@mit.edu>
@@ -16,8 +17,6 @@ from __future__ import absolute_import, division, print_function
 
 from neurodocker.utils import check_url, indent, manage_pkgs
 
-# find -type f -executable -exec /bin/bash -c "file -i '{}' | grep -q 'x-executable; charset=binary'" \; -print | xargs ldd | sed -n '/not\ found/p' | sed 's/=>.*//' | xargs -n1 | sort | uniq
-# docker run --rm -it -e DISPLAY=$(hostname):0 -v /private/tmp/.X11-unix:/tmp/.X11-unix -v ~/Downloads/linux_openmp_64:/opt/afni:ro kaczmarj/ants-deps
 
 class AFNI(object):
     """Add Dockerfile instructions to install AFNI.

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -90,17 +90,10 @@ class AFNI(object):
         pkgs = self._get_binaries_dependencies()
 
         cmd = ("{install}"
-               "\n&& {clean}"
-               '\n&& echo "Downloading AFNI ..."'
-               "\n&& mkdir -p /opt/afni"
-               "\n&& curl -sSL --retry 5 {}"
-               "\n| tar zx -C /opt/afni --strip-components=1"
-               "\n&& cp /opt/afni/AFNI.afnirc $HOME/.afnirc"
-               "\n&& cp /opt/afni/AFNI.sumarc $HOME/.sumarc"
                "\n&& ln /usr/lib/x86_64-linux-gnu/libgsl.so.19"
                " /usr/lib/x86_64-linux-gnu/libgsl.so.0"
                "\n|| true"
-               "".format(url, **manage_pkgs[self.pkg_manager]).format(pkgs=pkgs))
+               "".format(**manage_pkgs[self.pkg_manager]).format(pkgs=pkgs))
 
         if self.pkg_manager == "apt":
             # libxp was removed after ubuntu trusty.
@@ -108,10 +101,17 @@ class AFNI(object):
                        'libxp/libxp6_1.0.2-2_amd64.deb')
             cmd += ("\n&& apt-get install -yq libxp6"
                     '\n|| /bin/bash -c "'
-                    '\ncurl -o /tmp/libxp6.deb -sSL {}'
-                    '\n&& dpkg -i /tmp/libxp6.deb && rm -f /tmp/libxp6.deb"'
-                    "\n&& {clean}"
-                    ''.format(deb_url, **manage_pkgs[self.pkg_manager]))
+                    '\n   curl -o /tmp/libxp6.deb -sSL {}'
+                    '\n   && dpkg -i /tmp/libxp6.deb && rm -f /tmp/libxp6.deb"'
+                    ''.format(deb_url))
+
+        cmd += ('\n&& echo "Downloading AFNI ..."'
+                "\n&& mkdir -p /opt/afni"
+                "\n&& curl -sSL --retry 5 {}"
+                "\n| tar zx -C /opt/afni --strip-components=1"
+                "\n&& cp /opt/afni/AFNI.afnirc $HOME/.afnirc"
+                "\n&& cp /opt/afni/AFNI.sumarc $HOME/.sumarc"
+                "\n&& {clean}".format(url, **manage_pkgs[self.pkg_manager]))
         cmd = indent("RUN", cmd)
 
         env_cmd = "PATH=/opt/afni:$PATH"

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -1,0 +1,120 @@
+"""Add Dockerfile instructions to install AFNI.
+
+Homepage: https://afni.nimh.nih.gov/
+GitHub repo: https://github.com/afni/afni
+Documentation: https://afni.nimh.nih.gov/pub/dist/doc/htmldoc/index.html
+
+Notes
+-----
+- AFNI uses semantic versioning starting from 15.3.00, released on GitHub on
+  January 4, 2016. Before this, it is unclear how AFNI was versioned.
+- Only the latest binaries exist on AFNI's website.
+"""
+# Author: Jakub Kaczmarzyk <jakubk@mit.edu>
+
+from __future__ import absolute_import, division, print_function
+
+from neurodocker.utils import check_url, indent, manage_pkgs
+
+# find -type f -executable -exec /bin/bash -c "file -i '{}' | grep -q 'x-executable; charset=binary'" \; -print | xargs ldd | sed -n '/not\ found/p' | sed 's/=>.*//' | xargs -n1 | sort | uniq
+# docker run --rm -it -e DISPLAY=$(hostname):0 -v /private/tmp/.X11-unix:/tmp/.X11-unix -v ~/Downloads/linux_openmp_64:/opt/afni:ro kaczmarj/ants-deps
+
+class AFNI(object):
+    """Add Dockerfile instructions to install AFNI.
+
+    Parameters
+    ----------
+    version : str
+        AFNI version. Can be "latest" or version string.
+    pkg_manager : {'apt', 'yum'}
+        Linux package manager.
+    use_binaries : bool
+        If true, uses pre-compiled AFNI binaries. True by default.
+    check_urls : bool
+        If true, raise error if a URL used by this class responds with an error
+        code.
+    """
+
+    VERSION_TARBALLS = {
+        "latest": "https://afni.nimh.nih.gov/pub/dist/tgz/linux_openmp_64.tgz",
+        "17.2.02": "https://dl.dropbox.com/s/yd4umklaijydn13/afni-Linux-openmp64-v17.2.02.tgz",
+        }
+
+    def __init__(self, version, pkg_manager, use_binaries=True,
+                 check_urls=True):
+        self.version = version
+        self.pkg_manager = pkg_manager
+        self.use_binaries = use_binaries
+        self.check_urls = check_urls
+
+        self.cmd = self._create_cmd()
+
+    def _create_cmd(self):
+        """Return full command to install AFNI."""
+        comment = ("#--------------------\n"
+                   "# Install AFNI {}\n"
+                   "#--------------------".format(self.version))
+
+        if self.use_binaries:
+            chunks = [comment, self.install_binaries()]
+        else:
+            raise ValueError("`use_binaries=True` is the only available "
+                             "option at this time.")
+
+        return "\n".join(chunks)
+
+    def _get_binaries_urls(cls, version):
+        try:
+            return AFNI.VERSION_TARBALLS[version]
+        except KeyError:
+            raise ValueError("AFNI version not available: {}".format(version))
+
+    def _get_binaries_dependencies(self):
+        base_deps = {
+            'apt': 'gsl-bin libglu1-mesa-dev libglib2.0-0 libglw1-mesa libgomp1'
+                   '\nlibjpeg62 libxm4 netpbm tcsh xfonts-base xvfb',
+            'yum': 'ed gsl libGLU libgomp libpng12 libXp libXpm netpbm-progs'
+                   '\nopenmotif R-devel tcsh xorg-x11-fonts-misc'
+                   ' xorg-x11-server-Xvfb',
+        }
+        return base_deps[self.pkg_manager]
+
+    def install_binaries(self):
+        """Return Dockerfile instructions to download and install AFNI
+        binaries.
+        """
+        url = self._get_binaries_urls(self.version)
+        if self.check_urls:
+            check_url(url)
+
+        pkgs = self._get_binaries_dependencies()
+
+        cmd = ("{install}"
+               "\n&& {clean}"
+               '\n&& echo "Downloading AFNI ..."'
+               "\n&& mkdir -p /opt/afni"
+               "\n&& curl -sSL --retry 5 {}"
+               "\n| tar zx -C /opt/afni --strip-components=1"
+               "\n&& cp /opt/afni/AFNI.afnirc $HOME/.afnirc"
+               "\n&& cp /opt/afni/AFNI.sumarc $HOME/.sumarc"
+               "\n&& ln /usr/lib/x86_64-linux-gnu/libgsl.so.19"
+               " /usr/lib/x86_64-linux-gnu/libgsl.so.0"
+               "\n|| true"
+               "".format(url, **manage_pkgs[self.pkg_manager]).format(pkgs=pkgs))
+
+        if self.pkg_manager == "apt":
+            # libxp was removed after ubuntu trusty.
+            deb_url = ('http://mirrors.kernel.org/debian/pool/main/libx/'
+                       'libxp/libxp6_1.0.2-2_amd64.deb')
+            cmd += ("\n&& apt-get install -yq libxp6"
+                    '\n|| /bin/bash -c "'
+                    '\ncurl -o /tmp/libxp6.deb -sSL {}'
+                    '\n&& dpkg -i /tmp/libxp6.deb && rm -f /tmp/libxp6.deb"'
+                    "\n&& {clean}"
+                    ''.format(deb_url, **manage_pkgs[self.pkg_manager]))
+        cmd = indent("RUN", cmd)
+
+        env_cmd = "PATH=/opt/afni:$PATH"
+        env_cmd = indent("ENV", env_cmd)
+
+        return "\n".join((cmd, env_cmd))

--- a/neurodocker/interfaces/tests/test_afni.py
+++ b/neurodocker/interfaces/tests/test_afni.py
@@ -1,0 +1,28 @@
+"""Tests for neurodocker.interfaces.AFNI"""
+# Author: Jakub Kaczmarzyk <jakubk@mit.edu>
+
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from neurodocker.interfaces import AFNI
+from neurodocker.interfaces.tests import utils
+
+
+class TestAFNI(object):
+    """Tests for AFNI class."""
+
+    def test_build_image_afni_latest_binaries_centos7(self):
+        """Install latest AFNI binaries on CentOS 7."""
+        specs = {'base': 'centos:7',
+                 'pkg_manager': 'yum',
+                 'check_urls': True,
+                 'afni': {'version': 'latest', 'use_binaries': True}}
+        container = utils.get_container_from_specs(specs)
+        output = container.exec_run('3dSkullStrip')
+        assert "error" not in output, "error running 3dSkullStrip"
+        utils.test_cleanup(container)
+
+    def test_invalid_binaries(self):
+        with pytest.raises(ValueError):
+            AFNI(version='fakeversion', pkg_manager='apt', check_urls=False)

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -45,6 +45,8 @@ def _add_generate_arguments(parser):
                 "key=value pairs. Where applicable, the default installation "
                 "behavior is to install by downloading and uncompressing "
                 "binaries."),
+        "afni": ("Install AFNI. Valid keys are version (required). Only the "
+                 "latest version is supported at this time."),
         "ants": ("Install ANTs. Valid keys are version (required), "
                 "use_binaries (default true), and git_hash. If use_binaries="
                 "true, installs pre-compiled binaries; if use_binaries=false, "


### PR DESCRIPTION
This PR adds the ability to install AFNI. Only pre-compiled binaries for the latest version are available at this time, but binaries for earlier version will hopefully become available soon. The option to build from source will probably be added in the future.

3dSkullStrip and the main AFNI GUI were tested on Ubuntu Trusty and Xenial, CentOS 6 and 7, and Debian Wheezy and Jessie. The programs worked on all except Debian Jessie. For some reason, some shared libraries (e.g., libGLU and libXt) were not installed.

R is only installed in containers that use `yum` and not in containers that use `apt-get`. I am not sure how much AFNI depends on R, but some features might not be available in Debian-based AFNI images.

The required library libXp seems like it was removed from the apt repositories after Ubuntu Trusty. This class will install the Debian version of libXp using `dpkg` if it cannot be installed regularly using `apt-get`. This seems to work on Ubuntu Xenial.

**Running AFNI GUI in Docker**
I was able to run the AFNI GUI on macOS with XQuartz v2.7.8 using the following instructions. Open the XQuartz preferences, and in the "Security" tab, select the option to "Allow connections from network clients." Then, in the terminal, allow connections from the host:  `xhost + $(hostname)`. In the Docker preferences, allow the directory `/private/tmp/.X11-unix` to be bind mounted to Docker docker containers. Instructions on the Internet say to mount `/tmp/.X11-unix`, but on my machine, that directory was a shortcut to `/private/tmp/.X11-unix`. When running the AFNI Docker container, set the DISPLAY and bind the X11 directory, as below:

```shell
docker run --rm -it -e DISPLAY=$(hostname):0 -v /private/tmp/.X11-unix:/tmp/.X11-unix kaczmarj/afni:latest
```

Now, running `afni` in the container will display the GUI on the local machine.

---

A bash "one-liner" to find missing shared libraries:
```shell
find -type f -executable -exec /bin/bash -c "file -i '{}' | grep -q 'x-executable; charset=binary'" \; -print | xargs ldd | sed -n '/not\ found/p' | sed 's/=>.*//' | xargs -n1 | sort | uniq
```

