### PR TITLE
ADD: options to specify user, environment vars, and exposed ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ specs = {
     'base': 'ubuntu:17.04',
     'pkg_manager': 'apt',
     'check_urls': False,
-    'ants': {'version': '2.2.0'}}
+    'ants': {'version': '2.2.0'}
 }
 # Create Dockerfile.
 parser = SpecsParser(specs)

--- a/neurodocker/parser.py
+++ b/neurodocker/parser.py
@@ -19,7 +19,8 @@ class SpecsParser(object):
         The dictionary of specifications, or the name of the JSON file with the
         specifications.
     """
-    VALID_TOP_LEVEL_KEYS = ['base', 'pkg_manager', 'check_urls', 'instruction']
+    VALID_TOP_LEVEL_KEYS = ['base', 'pkg_manager', 'check_urls', 'instruction',
+                            'env', 'exposed_ports', 'user',]
     VALID_TOP_LEVEL_KEYS.extend(SUPPORTED_SOFTWARE.keys())
 
     def __init__(self, dict_or_filepath):

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -64,6 +64,21 @@ def test_parse_args():
     assert namespace.instruction
     assert isinstance(namespace.instruction, list)
 
+    args = base_args + ['--user', 'neuro']
+    namespace = parse_args(args)
+    assert namespace.user
+    assert isinstance(namespace.user, str)
+
+    args = base_args + ['--env', 'KEY=VALUE']
+    namespace = parse_args(args)
+    assert namespace.env
+    assert isinstance(namespace.env, list)
+
+    args = base_args + ['--port', '1234 1235']
+    namespace = parse_args(args)
+    assert namespace.exposed_ports
+    assert isinstance(namespace.exposed_ports, list)
+
     args = base_args + ['--no-check-urls']
     namespace = parse_args(args)
     assert not namespace.check_urls
@@ -143,6 +158,20 @@ def test_main():
     with pytest.raises(ValueError):
         main(args)
 
+def test_dockerfile_opts(capsys):
+    args = "generate -b ubuntu:17.04 -p apt --no-check-urls {}"
+    main(args.format('--user=neuro').split())
+    out, _ = capsys.readouterr()
+    assert "USER neuro" in out
+
+    main(args.format('--env KEY=VAL --env KEY2=VAL').split())
+    out, _ = capsys.readouterr()
+    assert "ENV KEY=VAL \\" in out
+    assert "  KEY2=VAL" in out
+
+    main(args.format('--port 1230 1231').split())
+    out, _ = capsys.readouterr()
+    assert "EXPOSE 1230 1231" in out
 
 def test_no_print(capsys):
     args = ['generate', '-b', 'ubuntu:17.04', '-p', 'apt', '--no-check-urls']


### PR DESCRIPTION
User is specified towards the end of the Dockerfile. Will this present permissions issues? I tested this by installing Miniconda (with jupyter notebook), curl, and ANTs as root, and I as a separate, non-root user, I was able to use these programs.

example:

```shell
neurodocker generate -b ubuntu:17.04 -p apt --user neuro --env KEY0=VAL0 --env KEY1=VAL1 --port 1230 1231
```