### PR TITLE
FIX+ENH: fix miniconda installation + allow creation of multiple conda environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ View source: [`neurodocker.interfaces.FSL`](neurodocker/interfaces/fsl.py).
 
 ## Miniconda
 
-Miniconda is installed using Miniconda's BASH installer. The latest version of Python 3 is installed to the root environment, and the `conda-forge` channel is added. A new conda environment is created with the requested specifications, the root environment is removed (to save space), and the new environment is prepended to `PATH`. To install Miniconda, include `'miniconda'` (case-insensitive) in the specifications dictionary Valid options are `'python_version'` (required; e.g., `'3.5.1'`), `'conda_install'` (e.g., `['numpy', 'traits']`), `pip_install` (e.g., `['nipype', 'pytest']`), and `miniconda_version` (`'latest'` by default).
+Miniconda is installed using Miniconda's BASH installer in `/opt/conda`. The latest version of Python 3 is installed to the root environment, and the `conda-forge` channel is added. A new conda environment is created with the requested specifications. To install Miniconda and create an environment, include `'miniconda'` (case-insensitive) in the specifications dictionary Valid options are `'env_name'` (required), `'python_version'` (required; e.g., `'3.5.1'`), `'conda_install'` (e.g., `['numpy', 'traits']`), `pip_install` (e.g., `['nipype', 'pytest']`), `'add_to_path'` (default true), and `miniconda_version` (`'latest'` by default). Multiple conda environments can be created with multiple `'miniconda'` items in the specifications dictionary. Miniconda is installed prior to the creation of the first environment.
 
 View source: [`neurodocker.interfaces.Miniconda`](neurodocker/interfaces/miniconda.py).
 
@@ -127,7 +127,7 @@ neurodocker generate -b debian:jessie -p yum \
 --freesurfer version=6.0.0 \
 --fsl version=5.0.10 \
 --user=neuro \
---miniconda python_version=3.5.1 conda_install="traits pandas" pip_install=nipype \
+--miniconda env_name=default python_version=3.5.1 conda_install="traits pandas" pip_install=nipype \
 --user=root \
 --mrtrix3 \
 --neurodebian os_codename="jessie" download_server="usa-nh" pkgs="dcm2niix" \
@@ -192,6 +192,7 @@ specs = {
         ('base', 'ubuntu:17.04'),
         ('user', 'neuro'),
         ('miniconda', {
+            'env_name': 'my_env',
             'python_version': '3.5.1',
             'conda_install': 'traits',
             'pip_install': 'https://github.com/nipy/nipype/archive/master.tar.gz'}),

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -99,9 +99,9 @@ def _add_common_dependencies(pkg_manager):
     cmd = "{install}\n&& {clean}".format(**manage_pkgs[pkg_manager])
     cmd = cmd.format(pkgs=deps)
     # Create directory for Miniconda as route and modify permissions so
-    # non-root users can create their environments there.
-    cmd += ("\n&& mkdir {0} && chgrp -R users {0}"
-            " && chmod 770 {0}".format(interfaces.Miniconda.INSTALL_PATH))
+    # non-root users can create their conda environments there.
+    cmd += ("\n&& mkdir {0} && chmod 777 {0}"
+            "".format(interfaces.Miniconda.INSTALL_PATH))
     cmd = indent("RUN", cmd)
 
     return "\n".join((comment, cmd))

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -70,9 +70,9 @@ class _DockerfileUsers(object):
         if user not in cls.initialized_users:
             cls.initialized_users.append(user)
             comment = "# Create new user: {0}"
-            inst_user = "RUN useradd --create-home --shell /bin/bash {0}"
+            inst_user = ("RUN useradd --no-user-group --create-home"
+                         " --shell /bin/bash {0}")
             instruction = "\n".join((comment, inst_user, instruction))
-
         return instruction.format(user)
 
     @classmethod
@@ -98,6 +98,10 @@ def _add_common_dependencies(pkg_manager):
                "#----------------------------")
     cmd = "{install}\n&& {clean}".format(**manage_pkgs[pkg_manager])
     cmd = cmd.format(pkgs=deps)
+    # Create directory for Miniconda as route and modify permissions so
+    # non-root users can create their environments there.
+    cmd += ("\n&& mkdir {0} && chgrp -R users {0}"
+            " && chmod 770 {0}".format(interfaces.Miniconda.INSTALL_PATH))
     cmd = indent("RUN", cmd)
 
     return "\n".join((comment, cmd))

--- a/neurodocker/interfaces/tests/test_miniconda.py
+++ b/neurodocker/interfaces/tests/test_miniconda.py
@@ -10,7 +10,7 @@ from neurodocker.interfaces.tests import utils
 class TestMiniconda(object):
     """Tests for Miniconda class."""
 
-    @pytest.mark.skip(reason="running container in background does not find correct Python")
+    #@pytest.mark.skip(reason="running container in background does not find correct Python")
     def test_build_image_miniconda_latest_shellscript_xenial(self):
         """Install latest version of Miniconda via ContinuumIO's installer
         script on Ubuntu Xenial.
@@ -21,9 +21,10 @@ class TestMiniconda(object):
                     ('base', 'centos:7'),
                     ('user', 'neuro'),
                     ('miniconda', {
-                        'python_version': '3.6.1',
-                        # 'conda_install': ['traits'],
-                        # 'pip_install': ['https://github.com/nipy/nipype/archive/master.tar.gz']
+                        'env_name': 'default',
+                        'python_version': '3.5.1',
+                        'conda_install': ['traits'],
+                        'pip_install': ['https://github.com/nipy/nipype/archive/master.tar.gz']
                     })
                  ]}
         container = utils.get_container_from_specs(specs)

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -63,43 +63,47 @@ def _add_generate_arguments(parser):
 
     # Software package options.
     pkgs_help = {
-        "all": ("Install software packages. Each argument takes a list of "
-                "key=value pairs. Where applicable, the default installation "
-                "behavior is to install by downloading and uncompressing "
-                "binaries."),
-        "afni": ("Install AFNI. Valid keys are version (required). Only the "
-                 "latest version is supported at this time."),
-        "ants": ("Install ANTs. Valid keys are version (required), "
-                "use_binaries (default true), and git_hash. If use_binaries="
-                "true, installs pre-compiled binaries; if use_binaries=false, "
-                "builds ANTs from source. If use_binaries is a URL, download "
-                "tarball of ANTs binaries from that URL. If git_hash is "
-                "specified, build from source from that commit."),
-        "freesurfer": ("Install FreeSurfer. Valid keys are version (required),"
-                       "license_path (relative path to license), and "
-                       "use_binaries (default true). A FreeSurfer license is "
-                       "required to run the software and is not provided by "
-                       "Neurodocker."),
-        "fsl": ("Install FSL. Valid keys are version (required), use_binaries "
-                "(default true) and use_installer."),
-        "miniconda": ("Install Miniconda. Valid keys are python_version "
-                      "(required), conda_install, pip_install, and "
-                      "miniconda_version (defaults to latest). The options "
-                      "conda_install and pip_install accept strings of "
-                      'packages: conda_install="traits numpy".'),
-        "mrtrix3": ("Install MRtrix3. Valid keys are use_binaries (default "
-                    "true) and git_hash. If git_hash is specified and "
-                    "use_binaries is false, will checkout to that commit "
-                    "before building."),
-        "neurodebian": ("Add NeuroDebian repository and optionally install "
-                        "NeuroDebian packages. Valid keys are os_codename "
-                        "(required; e.g., 'zesty'), download_server "
-                        "(required), full (if false, default, use libre "
-                        "packages), and pkgs (list of packages to install). "
-                        "Valid download servers are {}."
-                        "".format(_ndeb_servers)),
-        "spm": ("Install SPM (and its dependency, Matlab Compiler Runtime). "
-                "Valid keys are version and matlab_version."),
+        "all": (
+            "Install software packages. Each argument takes a list of"
+            " key=value pairs. Where applicable, the default installation"
+            " behavior is to install by downloading and uncompressing"
+            " binaries."),
+        "afni": (
+            "Install AFNI. Valid keys are version (required). Only the latest"
+            " version is supported at this time."),
+        "ants": (
+            "Install ANTs. Valid keys are version (required), use_binaries"
+            " (default true), and git_hash. If use_binaries=true, installs"
+            " pre-compiled binaries; if use_binaries=false, builds ANTs from"
+            " source. If git_hash is specified, build from source from that"
+            " commit."),
+        "freesurfer": (
+            "Install FreeSurfer. Valid keys are version (required),"
+            " license_path (relative path to license), and use_binaries"
+            " (default true). A FreeSurfer license is required to run the"
+            " software and is not provided by Neurodocker."),
+        "fsl": (
+            "Install FSL. Valid keys are version (required), use_binaries"
+            " (default true) and use_installer."),
+        "miniconda": (
+            "Install Miniconda. Valid keys are env_name (required),"
+            " python_version (required), conda_install, pip_install,"
+            " add_to_path (default true) and miniconda_version (defaults to"
+            " latest). The options conda_install and pip_install accept"
+            ' strings of packages: conda_install="traits numpy".'),
+        "mrtrix3": (
+            "Install MRtrix3. Valid keys are use_binaries (default true) and"
+            " git_hash. If git_hash is specified and use_binaries is false,"
+            " will checkout to that commit before building."),
+        "neurodebian": (
+            "Add NeuroDebian repository and optionally install NeuroDebian"
+            " packages. Valid keys are os_codename (required; e.g., 'zesty'),"
+            " download_server (required), full (if false, default, use libre"
+            " packages), and pkgs (list of packages to install). Valid"
+            " download servers are {}.".format(_ndeb_servers)),
+        "spm": (
+            "Install SPM (and its dependency, Matlab Compiler Runtime). Valid"
+            " keys are version and matlab_version."),
     }
 
     pkgs = p.add_argument_group(title="software package arguments",

--- a/neurodocker/tests/test_dockerfile.py
+++ b/neurodocker/tests/test_dockerfile.py
@@ -23,6 +23,7 @@ class TestDockerfile(object):
                       'instructions': [
                         ('base', 'ubuntu:17.04'),
                         ('miniconda', {'python_version': '3.5.1',
+                                       'env_name': 'default',
                                        'conda_install': 'numpy',
                                        'pip_install': 'pandas'}),
                         ('ants', {'version': '2.1.0', 'use_binaries': True}),

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -13,7 +13,7 @@ def test_main():
     args = ['generate', '-b', 'ubuntu:17.04', '-p', 'apt',
             '--ants', 'version=2.1.0',
             '--fsl', 'version=5.0.10',
-            '--miniconda', 'python_version=3.5.1',
+            '--miniconda', 'env_name=default', 'python_version=3.5.1',
             '--mrtrix3',
             '--neurodebian', 'os_codename=zesty', 'download_server=usa-nh',
             '--spm', 'version=12', 'matlab_version=R2017a',

--- a/neurodocker/utils.py
+++ b/neurodocker/utils.py
@@ -26,7 +26,8 @@ def _string_vals_to_bool(dictionary):
     """Convert string values to bool."""
     import re
 
-    bool_vars = ['use_binaries', 'use_installer', 'use_neurodebian']
+    bool_vars = ['use_binaries', 'use_installer', 'use_neurodebian',
+                 'add_to_path']
 
     if dictionary is None:
         return


### PR DESCRIPTION
Multiple conda environments can be created, but Miniconda is only installed right before the creation of the first environment. The folder `/opt/conda` is created and chmod'ed to 777 in every Docker image so that any user can create conda environments.