### PR TITLE
FIX+ADD+ENH: fix SPM permissions issue + add default entrypoint + support minimized freesurfer + other updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
       if [ "$INTERFACE_TO_BUILD" == 'none' ]; then
         python -m pytest -v -k "not test_build_image" --cov=./ neurodocker;
       elif [ "$INTERFACE_TO_BUILD" == 'afni' ]; then
-        python -m pytest -v --cov=./ neurodocker/interfaces/tests/test_afni.py;
+        python -m pytest -v -s --cov=./ neurodocker/interfaces/tests/test_afni.py;
       else
         travis_wait 50 python -m pytest -v -k "test_build_image_$INTERFACE_TO_BUILD" --cov=./ neurodocker;
       fi }

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
       if [ "$INTERFACE_TO_BUILD" == 'none' ]; then
         python -m pytest -v -k "not test_build_image" --cov=./ neurodocker;
       elif [ "$INTERFACE_TO_BUILD" == 'afni' ]; then
-        python -m pytest -v --cov=./ neurodocker/interfaces/test_afni.py
+        python -m pytest -v --cov=./ neurodocker/interfaces/test_afni.py;
       else
         travis_wait 50 python -m pytest -v -k "test_build_image_$INTERFACE_TO_BUILD" --cov=./ neurodocker;
       fi }

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
   - docker
 language: python
 python:
-  # - 2.7
   - 3.6
 branches:
   only:
@@ -29,8 +28,6 @@ script:
   - function run_tests {
       if [ "$INTERFACE_TO_BUILD" == 'none' ]; then
         python -m pytest -v -k "not test_build_image" --cov=./ neurodocker;
-      elif [ "$INTERFACE_TO_BUILD" == 'afni' ]; then
-        python -m pytest -v -s --cov=./ neurodocker/interfaces/tests/test_afni.py;
       else
         travis_wait 50 python -m pytest -v -k "test_build_image_$INTERFACE_TO_BUILD" --cov=./ neurodocker;
       fi }

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ script:
   - function run_tests {
       if [ "$INTERFACE_TO_BUILD" == 'none' ]; then
         python -m pytest -v -k "not test_build_image" --cov=./ neurodocker;
+      elif [ "$INTERFACE_TO_BUILD" == 'afni' ]; then
+        python -m pytest -v --cov=./ neurodocker/interfaces/test_afni.py
       else
         travis_wait 50 python -m pytest -v -k "test_build_image_$INTERFACE_TO_BUILD" --cov=./ neurodocker;
       fi }

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
       if [ "$INTERFACE_TO_BUILD" == 'none' ]; then
         python -m pytest -v -k "not test_build_image" --cov=./ neurodocker;
       elif [ "$INTERFACE_TO_BUILD" == 'afni' ]; then
-        python -m pytest -v --cov=./ neurodocker/interfaces/test_afni.py;
+        python -m pytest -v --cov=./ neurodocker/interfaces/tests/test_afni.py;
       else
         travis_wait 50 python -m pytest -v -k "test_build_image_$INTERFACE_TO_BUILD" --cov=./ neurodocker;
       fi }

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - INTERFACE_TO_BUILD=none
   - INTERFACE_TO_BUILD=afni
   - INTERFACE_TO_BUILD=ants
+  - INTERFACE_TO_BUILD=freesurfer
   - INTERFACE_TO_BUILD=fsl
   - INTERFACE_TO_BUILD=miniconda
   - INTERFACE_TO_BUILD=mrtrix3

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ View source: [`neurodocker.interfaces.FreeSurfer`](neurodocker/interfaces/freesu
 
 ## FSL
 
+FSL is non-free. If you are considering commercial use of FSL, please consult the [relevant license](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence).
+
 FSL can be installed using pre-compiled binaries (default behavior), FSL's Python installer (not on Debian-based systems), or through NeuroDebian. To install FSL, include `'fsl'` (case-insensitive) in the specifications dictionary. Valid options are `'version'` (e.g., `'5.0.10'`), `'use_binaries'` (bool), and `'use_installer'` (bool; to use FSL's Python installer). To install FSL from NeuroDebian, see the [NeuroDebian interface](#neurodebian).
 
 [FSL license](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence)  

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -178,10 +178,8 @@ def _add_common_dependencies(pkg_manager):
                "#----------------------------")
     cmd = "{install}\n&& {clean}".format(**manage_pkgs[pkg_manager])
     cmd = cmd.format(pkgs=deps)
-    # Create directory for Miniconda as route and modify permissions so
-    # non-root users can create their conda environments there.
-    cmd += ("\n&& mkdir {0} && chmod 777 {0}"
-            "".format(interfaces.Miniconda.INSTALL_PATH))
+    # Allow all users to read, write, and execute in /opt.
+    cmd += "\n&& chmod --recursive 777 /opt"
     cmd = indent("RUN", cmd)
 
     return "\n".join((comment, cmd))

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -169,7 +169,7 @@ def _add_common_dependencies(pkg_manager):
     pkg_manager : {'apt', 'yum'}
         Linux package manager.
     """
-    deps = "\n\tacl bzip2 ca-certificates curl unzip"
+    deps = "\n\tbzip2 ca-certificates curl unzip"
     if pkg_manager == "yum":
         deps += " epel-release"
 
@@ -179,9 +179,10 @@ def _add_common_dependencies(pkg_manager):
     cmd = "{install}\n&& {clean}".format(**manage_pkgs[pkg_manager])
     cmd = cmd.format(pkgs=deps)
     # Allow all users to read, write, and execute in /opt.
-    # https://superuser.com/a/151920
-    cmd += ("\n# Allow non-root users to read, write, execute in /opt."
-            "\n&& chmod g+s /opt && setfacl -Rd -m g::rwx,o::rwx /opt")
+    # Docker supports {} but AUFS, which does not support ACL, is the default.
+    # setfacl should not be used.
+    # cmd += ("\n# Allow non-root users to read, write, execute in /opt."
+    #         "\n&& chmod g+s /opt && setfacl -Rd -m g::rwx,o::rwx /opt")
     cmd = indent("RUN", cmd)
 
     return "\n".join((comment, cmd))

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -178,14 +178,19 @@ def _add_common_dependencies(pkg_manager):
                "#----------------------------")
     cmd = "{install}\n&& {clean}".format(**manage_pkgs[pkg_manager])
     cmd = cmd.format(pkgs=deps)
-    # Allow all users to read, write, and execute in /opt.
-    # Docker supports {} but AUFS, which does not support ACL, is the default.
-    # setfacl should not be used.
-    # cmd += ("\n# Allow non-root users to read, write, execute in /opt."
-    #         "\n&& chmod g+s /opt && setfacl -Rd -m g::rwx,o::rwx /opt")
+    cmd += ("\n# Allow non-root users to read, write, execute in /opt."
+            "\n&& chmod 777 /opt && chmod a+s /opt"
+            "\n# Create neurodocker's default entrypoint"
+            "\n&& mkdir /neurodocker"
+            "\n&& echo '#!/usr/bin/env bash' >> /neurodocker/startup.sh"
+            "\n&& echo 'set +x' >> /neurodocker/startup.sh"
+            "\n&& echo '$*' >> /neurodocker/startup.sh"
+            # "\n&& echo 'umask 002' >> /neurodocker/startup.sh"
+            "\n&& chmod -R 777 /neurodocker && chmod a+s /neurodocker")
     cmd = indent("RUN", cmd)
+    entrypoint = 'ENTRYPOINT ["/neurodocker/startup.sh"]'
 
-    return "\n".join((comment, cmd))
+    return "\n".join((comment, cmd, entrypoint))
 
 
 def _add_neurodocker_header():

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -184,8 +184,7 @@ def _add_common_dependencies(pkg_manager):
             "\n&& mkdir /neurodocker"
             "\n&& echo '#!/usr/bin/env bash' >> /neurodocker/startup.sh"
             "\n&& echo 'set +x' >> /neurodocker/startup.sh"
-            "\n&& echo '$*' >> /neurodocker/startup.sh"
-            # "\n&& echo 'umask 002' >> /neurodocker/startup.sh"
+            "\n&& echo 'if [ -z \"$*\" ]; then /usr/bin/env bash; else $*; fi' >> /neurodocker/startup.sh"
             "\n&& chmod -R 777 /neurodocker && chmod a+s /neurodocker")
     cmd = indent("RUN", cmd)
     entrypoint = 'ENTRYPOINT ["/neurodocker/startup.sh"]'

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -169,7 +169,7 @@ def _add_common_dependencies(pkg_manager):
     pkg_manager : {'apt', 'yum'}
         Linux package manager.
     """
-    deps = "bzip2 ca-certificates curl unzip"
+    deps = "\n\tacl bzip2 ca-certificates curl unzip"
     if pkg_manager == "yum":
         deps += " epel-release"
 
@@ -179,7 +179,9 @@ def _add_common_dependencies(pkg_manager):
     cmd = "{install}\n&& {clean}".format(**manage_pkgs[pkg_manager])
     cmd = cmd.format(pkgs=deps)
     # Allow all users to read, write, and execute in /opt.
-    cmd += "\n&& chmod --recursive 777 /opt"
+    # https://superuser.com/a/151920
+    cmd += ("\n# Allow non-root users to read, write, execute in /opt."
+            "\n&& chmod g+s /opt && setfacl -Rd -m g::rwx,o::rwx /opt")
     cmd = indent("RUN", cmd)
 
     return "\n".join((comment, cmd))

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -104,6 +104,14 @@ class AFNI(object):
                     '\n   && dpkg -i /tmp/libxp6.deb && rm -f /tmp/libxp6.deb"'
                     ''.format(deb_url))
 
+            deb_url = ('http://mirrors.kernel.org/debian/pool/main/libp/'
+                       'libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb')
+            cmd += ("\n&& apt-get install -yq libpng12"
+                    '\n|| /bin/bash -c "'
+                    '\n   curl -o /tmp/libpng12.deb -sSL {}'
+                    '\n   && dpkg -i /tmp/libpng12.deb && rm -f /tmp/libpng12.deb"'
+                    ''.format(deb_url))
+
         cmd += ("\n&& {clean}"
                 '\n&& echo "Downloading AFNI ..."'
                 "\n&& mkdir -p /opt/afni"

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -70,8 +70,8 @@ class AFNI(object):
 
     def _get_binaries_dependencies(self):
         base_deps = {
-            'apt': 'gsl-bin libglu1-mesa-dev libglib2.0-0 libglw1-mesa libgomp1'
-                   '\nlibjpeg62 libxm4 netpbm tcsh xfonts-base xvfb',
+            'apt': 'ed gsl-bin libglu1-mesa-dev libglib2.0-0 libglw1-mesa'
+                    '\nlibgomp1 libjpeg62 libxm4 netpbm tcsh xfonts-base xvfb',
             'yum': 'ed gsl libGLU libgomp libpng12 libXp libXpm netpbm-progs'
                    '\nopenmotif R-devel tcsh xorg-x11-fonts-misc'
                    ' xorg-x11-server-Xvfb',
@@ -132,11 +132,11 @@ class AFNI(object):
                 "\n&& mkdir -p /opt/afni"
                 "\n&& curl -sSL --retry 5 {}"
                 "\n| tar zx -C /opt/afni --strip-components=1"
-                "\n&& /opt/afni/rPkgsInstall -pkgs ALL -check"
+                "\n&& /opt/afni/rPkgsInstall -pkgs ALL"
                 "".format(url, **manage_pkgs[self.pkg_manager]))
         cmd = indent("RUN", cmd)
 
         env_cmd = "PATH=/opt/afni:$PATH"
         env_cmd = indent("ENV", env_cmd)
 
-        return "\n".join((cmd, env_cmd))
+        return "\n".join((env_cmd, cmd))

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -117,7 +117,7 @@ class AFNI(object):
 
             sh_url = ("https://gist.githubusercontent.com/kaczmarj/"
                       "8e3792ae1af70b03788163c44f453b43/raw/"
-                      "f6036cb55cd9252e46c34f109ba933a3215a0264/"
+                      "0577c62e4771236adf0191c826a25249eb69a130/"
                       "R_installer_debian_ubuntu.sh")
             cmd += ("\n# Install R"
                     "\n&& apt-get install -yq --no-install-recommends"

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -102,7 +102,7 @@ class AFNI(object):
             cmd += ("\n# Install libxp (not in all ubuntu/debian repositories)"
                     "\n&& apt-get install -yq --no-install-recommends libxp6"
                     '\n|| /bin/bash -c "'
-                    '\n   curl -o /tmp/libxp6.deb -sSL {}'
+                    '\n   curl --retry 5 -o /tmp/libxp6.deb -sSL {}'
                     '\n   && dpkg -i /tmp/libxp6.deb && rm -f /tmp/libxp6.deb"'
                     ''.format(deb_url))
 

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -89,16 +89,18 @@ class AFNI(object):
         pkgs = self._get_binaries_dependencies()
 
         cmd = ("{install}"
-               "\n&& ln /usr/lib/x86_64-linux-gnu/libgsl.so.19"
-               " /usr/lib/x86_64-linux-gnu/libgsl.so.0"
-               "\n|| true"
+               '\n&& libs_path=/usr/lib/x86_64-linux-gnu'
+               '\n&& if [ -f $libs_path/libgsl.so.19 ]; then'
+               '\n       ln $libs_path/libgsl.so.19 $libs_path/libgsl.so.0;'
+               '\n   fi'
                "".format(**manage_pkgs[self.pkg_manager]).format(pkgs=pkgs))
 
         if self.pkg_manager == "apt":
             # libxp was removed after ubuntu trusty.
             deb_url = ('http://mirrors.kernel.org/debian/pool/main/libx/'
                        'libxp/libxp6_1.0.2-2_amd64.deb')
-            cmd += ("\n&& apt-get install -yq libxp6"
+            cmd += ("\n# Install libxp (not in all ubuntu/debian repositories)"
+                    "\n&& apt-get install -yq --no-install-recommends libxp6"
                     '\n|| /bin/bash -c "'
                     '\n   curl -o /tmp/libxp6.deb -sSL {}'
                     '\n   && dpkg -i /tmp/libxp6.deb && rm -f /tmp/libxp6.deb"'
@@ -106,19 +108,31 @@ class AFNI(object):
 
             deb_url = ('http://mirrors.kernel.org/debian/pool/main/libp/'
                        'libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb')
-            cmd += ("\n&& apt-get install -yq libpng12"
+            cmd += ("\n# Install libpng12 (not in all ubuntu/debian repositories)"
+                    "\n&& apt-get install -yq --no-install-recommends libpng12-0"
                     '\n|| /bin/bash -c "'
                     '\n   curl -o /tmp/libpng12.deb -sSL {}'
                     '\n   && dpkg -i /tmp/libpng12.deb && rm -f /tmp/libpng12.deb"'
                     ''.format(deb_url))
+
+            sh_url = ("https://gist.githubusercontent.com/kaczmarj/"
+                      "8e3792ae1af70b03788163c44f453b43/raw/"
+                      "f6036cb55cd9252e46c34f109ba933a3215a0264/"
+                      "R_installer_debian_ubuntu.sh")
+            cmd += ("\n# Install R"
+                    "\n&& apt-get install -yq --no-install-recommends"
+                    "\n\tr-base-dev r-cran-rmpi"
+                    '\n || /bin/bash -c "'
+                    '\n    curl -o /tmp/install_R.sh -sSL {}'
+                    '\n    && /bin/bash /tmp/install_R.sh"'
+                    ''.format(sh_url))
 
         cmd += ("\n&& {clean}"
                 '\n&& echo "Downloading AFNI ..."'
                 "\n&& mkdir -p /opt/afni"
                 "\n&& curl -sSL --retry 5 {}"
                 "\n| tar zx -C /opt/afni --strip-components=1"
-                "\n&& cp /opt/afni/AFNI.afnirc $HOME/.afnirc"
-                "\n&& cp /opt/afni/AFNI.sumarc $HOME/.sumarc"
+                "\n&& /opt/afni/rPkgsInstall -pkgs ALL -check"
                 "".format(url, **manage_pkgs[self.pkg_manager]))
         cmd = indent("RUN", cmd)
 

--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -133,6 +133,7 @@ class AFNI(object):
                 "\n&& curl -sSL --retry 5 {}"
                 "\n| tar zx -C /opt/afni --strip-components=1"
                 "\n&& /opt/afni/rPkgsInstall -pkgs ALL"
+                "\n&& rm -rf /tmp/*"
                 "".format(url, **manage_pkgs[self.pkg_manager]))
         cmd = indent("RUN", cmd)
 

--- a/neurodocker/interfaces/freesurfer.py
+++ b/neurodocker/interfaces/freesurfer.py
@@ -150,7 +150,7 @@ class FreeSurfer(object):
                 "".format(url=url, excluded=excluded_dirs))
 
         cmd += ("\n&& sed -i '$isource $FREESURFER_HOME/SetUpFreeSurfer.sh'"
-                " /neurodocker/startup.sh")
+                " $ND_ENTRYPOINT")
         cmd = indent("RUN", cmd)
 
         env_cmd = "ENV FREESURFER_HOME=/opt/freesurfer"
@@ -170,7 +170,7 @@ class FreeSurfer(object):
         cmd += ('\n&& echo "Downloading minimized FreeSurfer ..."'
                 "\n&& curl -sSL {} | tar xz -C /opt"
                 "\n&& sed -i '$isource $FREESURFER_HOME/SetUpFreeSurfer.sh'"
-                " /neurodocker/startup.sh"
+                " $ND_ENTRYPOINT"
                 "".format(url))
         cmd = indent("RUN", cmd)
         env_cmd = "ENV FREESURFER_HOME=/opt/freesurfer"

--- a/neurodocker/interfaces/freesurfer.py
+++ b/neurodocker/interfaces/freesurfer.py
@@ -25,6 +25,8 @@ class FreeSurfer(object):
         version='dev'.
     pkg_manager : {'apt', 'yum'}
         Linux package manager.
+    min : bool
+        If true, install FreeSurfer minimized for recon-all.
     license_path : str
         Relative path to license.txt file. If provided, adds a COPY instruction
         to copy the file into $FREESURFER_HOME (always /opt/freesurfer/).
@@ -36,10 +38,11 @@ class FreeSurfer(object):
         code.
     """
 
-    def __init__(self, version, pkg_manager, license_path=None,
+    def __init__(self, version, pkg_manager, min=False, license_path=None,
                  use_binaries=True, check_urls=True):
         self.version = version
         self.pkg_manager = pkg_manager
+        self.min = min
         self.license_path = license_path
         self.use_binaries = use_binaries
         self.check_urls = check_urls
@@ -52,8 +55,18 @@ class FreeSurfer(object):
                    "# Install FreeSurfer v{}\n"
                    "#--------------------------".format(self.version))
 
-        if self.use_binaries:
-            chunks = [comment, self.install_binaries()]
+        chunks = [comment]
+
+        if self.min:
+            if self.version != "6.0.0":
+                raise ValueError("Minimized version is only avialable for"
+                                 " FreeSurfer version 6.0.0")
+            min_comment = ("# Install version minimized for recon-all"
+                           "\n# See https://github.com/freesurfer/freesurfer/issues/70")
+            chunks.append(min_comment)
+            chunks.append(self.add_min_recon_all())
+        elif self.use_binaries:
+            chunks.append(self.install_binaries())
         else:
             raise ValueError("Installation via binaries is the only available "
                              "installation method for now.")
@@ -136,19 +149,32 @@ class FreeSurfer(object):
                 "\n| tar xz -C /opt\n{excluded}"
                 "".format(url=url, excluded=excluded_dirs))
 
-        entrypoint = "/opt/freesurfer/neurodocker_freesurfer_startup.sh"
-        cmd += ("\n&& entrypoint={}"
-                "\n&& echo '#!/usr/bin/env bash' > $entrypoint"
-                "\n&& echo 'set +x' > $entrypoint"
-                "\n&& echo 'source $FREESURFER_HOME/SetUpFreeSurfer.sh' >> $entrypoint"
-                "\n&& echo '$*' >> $entrypoint"
-                "").format(entrypoint)
+        cmd += ("\n&& sed -i '$isource $FREESURFER_HOME/SetUpFreeSurfer.sh'"
+                " /neurodocker/startup.sh")
         cmd = indent("RUN", cmd)
 
         env_cmd = "ENV FREESURFER_HOME=/opt/freesurfer"
-        entrypoint_cmd = 'ENTRYPOINT ["/bin/bash", "{}"]'.format(entrypoint)
 
-        return "\n".join((cmd, env_cmd, entrypoint_cmd))
+        return "\n".join((cmd, env_cmd))
+
+    def add_min_recon_all(self):
+        """Return Dockerfile instructions to install minimized version of
+        recon-all.
+
+        See https://github.com/freesurfer/freesurfer/issues/70 for more
+        information.
+        """
+        cmd = self._install_binaries_deps()
+        url = ("https://dl.dropbox.com/s/nnzcfttc41qvt31/"
+               "recon-all-freesurfer6-3.min.tgz")
+        cmd += ('\n&& echo "Downloading minimized FreeSurfer ..."'
+                "\n&& curl -sSL {} | tar xz -C /opt"
+                "\n&& sed -i '$isource $FREESURFER_HOME/SetUpFreeSurfer.sh'"
+                " /neurodocker/startup.sh"
+                "".format(url))
+        cmd = indent("RUN", cmd)
+        env_cmd = "ENV FREESURFER_HOME=/opt/freesurfer"
+        return "\n".join((cmd, env_cmd))
 
     def _copy_license(self):
         """Return command to copy local license file into the container. Path

--- a/neurodocker/interfaces/fsl.py
+++ b/neurodocker/interfaces/fsl.py
@@ -66,11 +66,12 @@ class FSL(object):
 
     def _create_cmd(self):
         """Return full Dockerfile instructions to install FSL."""
-        comment = ("#-----------------------------------------------"
-                   "\n# Install FSL {}"
-                   "\n# Please review FSL's license:"
+        comment = ("#-----------------------------------------------------------"
+                   "\n# Install FSL v{}"
+                   "\n# FSL is non-free. If you are considering commerical use"
+                   "\n# of this Docker image, please consult the relevant license:"
                    "\n# https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence"
-                   "\n#-----------------------------------------------"
+                   "\n#-----------------------------------------------------------"
                    "".format(self.version))
         if self.use_binaries:
             url = self._get_binaries_url()
@@ -130,9 +131,13 @@ class FSL(object):
         cmd += ("\n&& entrypoint={}"
                 "\n&& echo '#!/usr/bin/env bash' > $entrypoint"
                 "\n&& echo 'set +x' > $entrypoint"
+                "\n&& echo 'echo \"Some packages in this Docker container are non-free.\"' >> $entrypoint"
+                "\n&& echo 'echo \"If you are considering commercial use of"
+                " this container, please consult the relevant license:\"' >> $entrypoint"
+                "\n&& echo 'echo https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence' >> $entrypoint"
                 "\n&& echo 'source ${{FSLDIR}}/etc/fslconf/fsl.sh' >> $entrypoint"
                 "\n&& echo '$*' >> $entrypoint"
-                "\n&& chmod 755 $entrypoint").format(entrypoint)
+                "").format(entrypoint)
         cmd = indent("RUN", cmd)
 
         env_cmd = ("FSLDIR=/opt/fsl"

--- a/neurodocker/interfaces/fsl.py
+++ b/neurodocker/interfaces/fsl.py
@@ -127,14 +127,11 @@ class FSL(object):
             fsl_python = "/opt/fsl/etc/fslconf/fslpython_install.sh"
             cmd +=  "\n&& /bin/bash {} -q -f /opt/fsl".format(fsl_python)
 
-        entrypoint = "/neurodocker/startup.sh"
-        cmd += ("\n&& entrypoint={}"
-                "\n&& sed -i '$iecho Some packages in this Docker container are non-free' $entrypoint"
+        cmd += ("\n&& sed -i '$iecho Some packages in this Docker container are non-free' $ND_ENTRYPOINT"
                 "\n&& sed -i '$iecho If you are considering commercial use of"
-                " this container, please consult the relevant license:\"' $entrypoint"
-                "\n&& sed -i '$iecho https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence' $entrypoint"
-                "\n&& sed -i '$isource $FSLDIR/etc/fslconf/fsl.sh' $entrypoint"
-                "").format(entrypoint)
+                " this container, please consult the relevant license:' $ND_ENTRYPOINT"
+                "\n&& sed -i '$iecho https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence' $ND_ENTRYPOINT"
+                "\n&& sed -i '$isource $FSLDIR/etc/fslconf/fsl.sh' $ND_ENTRYPOINT")
         cmd = indent("RUN", cmd)
 
         env_cmd = ("FSLDIR=/opt/fsl"

--- a/neurodocker/interfaces/fsl.py
+++ b/neurodocker/interfaces/fsl.py
@@ -127,16 +127,13 @@ class FSL(object):
             fsl_python = "/opt/fsl/etc/fslconf/fslpython_install.sh"
             cmd +=  "\n&& /bin/bash {} -q -f /opt/fsl".format(fsl_python)
 
-        entrypoint = "/opt/fsl/neurodocker_fsl_startup.sh"
+        entrypoint = "/neurodocker/startup.sh"
         cmd += ("\n&& entrypoint={}"
-                "\n&& echo '#!/usr/bin/env bash' > $entrypoint"
-                "\n&& echo 'set +x' > $entrypoint"
-                "\n&& echo 'echo \"Some packages in this Docker container are non-free.\"' >> $entrypoint"
-                "\n&& echo 'echo \"If you are considering commercial use of"
-                " this container, please consult the relevant license:\"' >> $entrypoint"
-                "\n&& echo 'echo https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence' >> $entrypoint"
-                "\n&& echo 'source ${{FSLDIR}}/etc/fslconf/fsl.sh' >> $entrypoint"
-                "\n&& echo '$*' >> $entrypoint"
+                "\n&& sed -i '$iecho Some packages in this Docker container are non-free' $entrypoint"
+                "\n&& sed -i '$iecho If you are considering commercial use of"
+                " this container, please consult the relevant license:\"' $entrypoint"
+                "\n&& sed -i '$iecho https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence' $entrypoint"
+                "\n&& sed -i '$isource $FSLDIR/etc/fslconf/fsl.sh' $entrypoint"
                 "").format(entrypoint)
         cmd = indent("RUN", cmd)
 
@@ -144,6 +141,4 @@ class FSL(object):
                    "\nPATH=/opt/fsl/bin:$PATH")
         env_cmd = indent("ENV", env_cmd)
 
-        entrypoint_cmd = 'ENTRYPOINT ["/bin/bash", "{}"]'.format(entrypoint)
-
-        return "\n".join((cmd, env_cmd, entrypoint_cmd))
+        return "\n".join((cmd, env_cmd))

--- a/neurodocker/interfaces/neurodebian.py
+++ b/neurodocker/interfaces/neurodebian.py
@@ -92,8 +92,11 @@ class NeuroDebian(object):
                "\n&& {clean}"
                "\n&& curl -sSL {url}"
                "\n> /etc/apt/sources.list.d/neurodebian.sources.list"
-               "\n&& apt-key adv --recv-keys --keyserver"
-               " hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9"
+               "\n&& apt-key adv --fetch-keys https://dl.dropbox.com/s/zxs209o955q6vkg/neurodebian.gpg"
+               # Syntax from
+               # https://github.com/poldracklab/fmriprep/blob/master/Dockerfile#L21
+               "\n&& (apt-key adv --refresh-keys --keyserver"
+               " hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9 || true)"
                "\n&& apt-get update"
                "".format(url=self.url, **manage_pkgs['apt']).format(pkgs=pkgs))
         return indent("RUN", cmd)

--- a/neurodocker/interfaces/neurodebian.py
+++ b/neurodocker/interfaces/neurodebian.py
@@ -17,8 +17,8 @@ class NeuroDebian(object):
         The server to use to download NeuroDebian packages. Choose the one
         closest to you.
     full : bool
-        If false (default), use the libre sources. If true, use the full
-        NeuroDebian sources.
+        If true (default), use the full NeuroDebian sources. If false, use the
+        libre sources.
     pkgs : str or list or tuple
         Packages to install from NeuroDebian.
     pkg_manager : {'apt'}
@@ -40,7 +40,7 @@ class NeuroDebian(object):
                'usa-nh': 'us-nh',
                'usa-tn': 'us-tn',}
 
-    def __init__(self, os_codename, download_server, full=False, pkgs=None,
+    def __init__(self, os_codename, download_server, full=True, pkgs=None,
                  pkg_manager='apt', check_urls=True):
         self.pkgs = pkgs
         self.check_urls = check_urls
@@ -54,9 +54,11 @@ class NeuroDebian(object):
         self.cmd = self._create_cmd()
 
     def _create_cmd(self):
-        comment = ("#---------------------------"
+        comment = ("#--------------------------------------------------"
                    "\n# Add NeuroDebian repository"
-                   "\n#---------------------------")
+                   "\n# Please note that some packages downloaded through"
+                   "\n# NeuroDebian may have restrictive licenses."
+                   "\n#--------------------------------------------------")
 
         chunks = [comment, self._add_neurodebian()]
         if self.pkgs is not None and self.pkgs:

--- a/neurodocker/interfaces/spm.py
+++ b/neurodocker/interfaces/spm.py
@@ -94,14 +94,13 @@ class SPM(object):
     def install_mcr(url):
         """Return Dockerfile instructions to install MATLAB Compiler Runtime."""
         comment = "# Install MATLAB Compiler Runtime"
-        workdir_cmd = "WORKDIR /opt"
         cmd = ('echo "Downloading MATLAB Compiler Runtime ..."'
-               "\n&& curl -sSL -o mcr.zip {}"
-               "\n&& unzip -q mcr.zip -d mcrtmp"
-               "\n&& mcrtmp/install -destinationFolder /opt/mcr -mode silent -agreeToLicense yes"
-               "\n&& rm -rf mcrtmp mcr.zip /tmp/*".format(url))
+               "\n&& curl -sSL -o /tmp/mcr.zip {}"
+               "\n&& unzip -q /tmp/mcr.zip -d /tmp/mcrtmp"
+               "\n&& /tmp/mcrtmp/install -destinationFolder /opt/mcr -mode silent -agreeToLicense yes"
+               "\n&& rm -rf /tmp/*".format(url))
         cmd = indent("RUN", cmd)
-        return '\n'.join((comment, workdir_cmd, cmd))
+        return '\n'.join((comment, cmd))
 
     def _get_spm_url(self):
         url = ("http://www.fil.ion.ucl.ac.uk/spm/download/restricted/"
@@ -115,10 +114,9 @@ class SPM(object):
     def install_spm(url):
         """Return Dockerfile instructions to install standalone SPM."""
         comment = "# Install standalone SPM"
-        workdir_cmd = "WORKDIR /opt"
         cmd = ('echo "Downloading standalone SPM ..."'
                "\n&& curl -sSL -o spm.zip {}"
-               "\n&& unzip -q spm.zip"
+               "\n&& unzip -q spm.zip -d /opt/spm"
                "\n&& rm -rf spm.zip\n".format(url))
         cmd = indent("RUN", cmd)
 
@@ -127,4 +125,4 @@ class SPM(object):
                    "\nFORCE_SPMMCR=1"
                    "\nLD_LIBRARY_PATH=/opt/mcr/v*/runtime/glnxa64:/opt/mcr/v*/bin/glnxa64:/opt/mcr/v*/sys/os/glnxa64:$LD_LIBRARY_PATH")
         env_cmd = indent("ENV", env_cmd)
-        return '\n'.join((comment, workdir_cmd, cmd, env_cmd))
+        return '\n'.join((comment, cmd, env_cmd))

--- a/neurodocker/interfaces/spm.py
+++ b/neurodocker/interfaces/spm.py
@@ -52,6 +52,8 @@ class SPM(object):
 
         if self.version not in ['12']:
             raise ValueError("Only SPM12 is supported (for now).")
+        if self.matlab_version != "R2017a":
+            raise ValueError("Only MATLAB R2017a is supported (for now).")
 
         self.cmd = self._create_cmd()
 
@@ -117,9 +119,10 @@ class SPM(object):
                "\n&& rm -rf spm.zip\n".format(url))
         cmd = indent("RUN", cmd)
 
-        env_cmd = ("MATLABCMD=/opt/mcr/v*/toolbox/matlab"
-                   '\nSPMMCRCMD="/opt/spm*/run_spm*.sh /opt/mcr/v*/ script"'
+        # TODO: look into the different MCR versions and find their path.
+        env_cmd = ("MATLABCMD=/opt/mcr/v92/toolbox/matlab"
+                   '\nSPMMCRCMD="/opt/spm12/run_spm12.sh /opt/mcr/v92/ script"'
                    "\nFORCE_SPMMCR=1"
-                   "\nLD_LIBRARY_PATH=/opt/mcr/v*/runtime/glnxa64:/opt/mcr/v*/bin/glnxa64:/opt/mcr/v*/sys/os/glnxa64:$LD_LIBRARY_PATH")
+                   "\nLD_LIBRARY_PATH=/opt/mcr/v92/runtime/glnxa64:/opt/mcr/v92/bin/glnxa64:/opt/mcr/v92/sys/os/glnxa64:$LD_LIBRARY_PATH")
         env_cmd = indent("ENV", env_cmd)
         return '\n'.join((comment, cmd, env_cmd))

--- a/neurodocker/interfaces/spm.py
+++ b/neurodocker/interfaces/spm.py
@@ -113,6 +113,7 @@ class SPM(object):
         cmd = ('echo "Downloading standalone SPM ..."'
                "\n&& curl -sSL -o spm.zip {}"
                "\n&& unzip -q spm.zip -d /opt"
+               "\n&& chmod -R 777 /opt/spm*"
                "\n&& rm -rf spm.zip\n".format(url))
         cmd = indent("RUN", cmd)
 

--- a/neurodocker/interfaces/tests/test_afni.py
+++ b/neurodocker/interfaces/tests/test_afni.py
@@ -18,7 +18,8 @@ class TestAFNI(object):
                  'check_urls': True,
                  'instructions': [
                     ('base', 'centos:7'),
-                    ('afni', {'version': 'latest', 'use_binaries': True})
+                    ('afni', {'version': 'latest', 'use_binaries': True}),
+                    ('user', 'neuro'),
                  ]}
 
         container = utils.get_container_from_specs(specs)

--- a/neurodocker/interfaces/tests/test_afni.py
+++ b/neurodocker/interfaces/tests/test_afni.py
@@ -12,12 +12,12 @@ from neurodocker.interfaces.tests import utils
 class TestAFNI(object):
     """Tests for AFNI class."""
 
-    def test_build_image_afni_latest_binaries_centos7(self):
-        """Install latest AFNI binaries on CentOS 7."""
-        specs = {'pkg_manager': 'yum',
+    def test_build_image_afni_latest_binaries_stretch(self):
+        """Install latest AFNI binaries on Debian stretch."""
+        specs = {'pkg_manager': 'apt',
                  'check_urls': True,
                  'instructions': [
-                    ('base', 'centos:7'),
+                    ('base', 'debian:stretch'),
                     ('afni', {'version': 'latest', 'use_binaries': True}),
                     ('user', 'neuro'),
                  ]}

--- a/neurodocker/interfaces/tests/test_ants.py
+++ b/neurodocker/interfaces/tests/test_ants.py
@@ -18,7 +18,8 @@ class TestANTs(object):
                  'check_urls': True,
                  'instructions': [
                     ('base', 'centos:7'),
-                    ('ants', {'version': '2.2.0', 'use_binaries': True})
+                    ('ants', {'version': '2.2.0', 'use_binaries': True}),
+                    ('user', 'neuro'),
                  ]}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('Atropos')

--- a/neurodocker/interfaces/tests/test_freesurfer.py
+++ b/neurodocker/interfaces/tests/test_freesurfer.py
@@ -11,18 +11,18 @@ from neurodocker.interfaces.tests import utils
 class TestFreeSurfer(object):
     """Tests for FreeSurfer class."""
 
-    @pytest.mark.skip(reason="requirements exceed available resources")
-    def test_build_image_freesurfer_600_binaries_xenial(self):
-        """Install FSL binaries on Ubuntu Xenial."""
+    def test_build_image_freesurfer_600_min_binaries_xenial(self):
+        """Install minimized FreeSurfer binaries on Ubuntu Xenial."""
         specs = {'pkg_manager': 'apt',
                  'check_urls': True,
                  'instructions': [
                     ('base', 'ubuntu:xenial'),
-                    ('freesurfer', {'version': '6.0.0', 'use_binaries': True}),
+                    ('freesurfer', {'version': '6.0.0', 'use_binaries': True,
+                                    'min': True}),
                     ('user', 'neuro'),
                  ]}
         container = utils.get_container_from_specs(specs)
-        output = container.exec_run('recon-all')
+        output = container.exec_run('bash -c "recon-all"')
         assert "error" not in output, "error running recon-all"
         utils.test_cleanup(container)
 

--- a/neurodocker/interfaces/tests/test_freesurfer.py
+++ b/neurodocker/interfaces/tests/test_freesurfer.py
@@ -18,7 +18,8 @@ class TestFreeSurfer(object):
                  'check_urls': True,
                  'instructions': [
                     ('base', 'ubuntu:xenial'),
-                    ('freesurfer', {'version': '6.0.0', 'use_binaries': True})
+                    ('freesurfer', {'version': '6.0.0', 'use_binaries': True}),
+                    ('user', 'neuro'),
                  ]}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('recon-all')

--- a/neurodocker/interfaces/tests/test_fsl.py
+++ b/neurodocker/interfaces/tests/test_fsl.py
@@ -25,7 +25,7 @@ class TestFSL(object):
         assert "error" not in output, "error running bet"
         utils.test_cleanup(container)
 
-    def test_build_image_fsl_509_binaries_stretch(self):
+    def test_build_image_fsl_5010_binaries_stretch(self):
         """Install FSL binaries on Debian Stretch."""
         specs = {'pkg_manager': 'apt',
                  'check_urls': True,

--- a/neurodocker/interfaces/tests/test_fsl.py
+++ b/neurodocker/interfaces/tests/test_fsl.py
@@ -17,20 +17,21 @@ class TestFSL(object):
                  'check_urls': True,
                  'instructions': [
                     ('base', 'centos:7'),
-                    ('fsl', {'version': '5.0.10', 'use_binaries': True})
+                    ('fsl', {'version': '5.0.10', 'use_binaries': True}),
+                    ('user', 'neuro'),
                  ]}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('bet')
         assert "error" not in output, "error running bet"
         utils.test_cleanup(container)
 
-    def test_build_image_fsl_509_binaries_xenial(self):
-        """Install FSL binaries on Ubuntu Xenial."""
+    def test_build_image_fsl_509_binaries_stretch(self):
+        """Install FSL binaries on Debian Stretch."""
         specs = {'pkg_manager': 'apt',
                  'check_urls': True,
                  'instructions': [
-                    ('base', 'ubuntu:xenial'),
-                    ('fsl', {'version': '5.0.9', 'use_binaries': True})
+                    ('base', 'debian:stretch'),
+                    ('fsl', {'version': '5.0.10', 'use_binaries': True})
                  ]}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('bet')

--- a/neurodocker/interfaces/tests/test_fsl.py
+++ b/neurodocker/interfaces/tests/test_fsl.py
@@ -21,7 +21,7 @@ class TestFSL(object):
                     ('user', 'neuro'),
                  ]}
         container = utils.get_container_from_specs(specs)
-        output = container.exec_run('bet')
+        output = container.exec_run('bash -c "bet"')
         assert "error" not in output, "error running bet"
         utils.test_cleanup(container)
 
@@ -34,6 +34,6 @@ class TestFSL(object):
                     ('fsl', {'version': '5.0.9', 'use_binaries': True})
                  ]}
         container = utils.get_container_from_specs(specs)
-        output = container.exec_run('bet')
+        output = container.exec_run('bash -c "bet"')
         assert "error" not in output, "error running bet"
         utils.test_cleanup(container)

--- a/neurodocker/interfaces/tests/test_fsl.py
+++ b/neurodocker/interfaces/tests/test_fsl.py
@@ -25,13 +25,13 @@ class TestFSL(object):
         assert "error" not in output, "error running bet"
         utils.test_cleanup(container)
 
-    def test_build_image_fsl_5010_binaries_stretch(self):
+    def test_build_image_fsl_509_binaries_stretch(self):
         """Install FSL binaries on Debian Stretch."""
         specs = {'pkg_manager': 'apt',
                  'check_urls': True,
                  'instructions': [
                     ('base', 'debian:stretch'),
-                    ('fsl', {'version': '5.0.10', 'use_binaries': True})
+                    ('fsl', {'version': '5.0.9', 'use_binaries': True})
                  ]}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('bet')

--- a/neurodocker/interfaces/tests/test_miniconda.py
+++ b/neurodocker/interfaces/tests/test_miniconda.py
@@ -25,7 +25,8 @@ class TestMiniconda(object):
                         'python_version': '3.5.1',
                         'conda_install': ['traits'],
                         'pip_install': ['https://github.com/nipy/nipype/archive/master.tar.gz']
-                    })
+                    }),
+                    ('user', 'neuro'),
                  ]}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('python -V')

--- a/neurodocker/interfaces/tests/test_mrtrix.py
+++ b/neurodocker/interfaces/tests/test_mrtrix.py
@@ -18,7 +18,8 @@ class TestMRtrix3(object):
                  'check_urls': True,
                  'instructions': [
                     ('base', 'centos:7'),
-                    ('mrtrix3', {'use_binaries': True})
+                    ('mrtrix3', {'use_binaries': True}),
+                    ('user', 'neuro'),
                  ]}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('mrinfo')

--- a/neurodocker/interfaces/tests/test_neurodebian.py
+++ b/neurodocker/interfaces/tests/test_neurodebian.py
@@ -20,7 +20,8 @@ class TestNeuroDebian(object):
                     ('neurodebian', {'os_codename': 'xenial',
                                     'download_server': 'usa-nh',
                                     'full': False,
-                                    'pkgs': ['dcm2niix']})
+                                    'pkgs': ['dcm2niix']}),
+                    ('user', 'neuro'),
                 ]}
         container = utils.get_container_from_specs(specs)
         output = container.exec_run('dcm2niix -h')

--- a/neurodocker/interfaces/tests/test_neurodebian.py
+++ b/neurodocker/interfaces/tests/test_neurodebian.py
@@ -16,10 +16,10 @@ class TestNeuroDebian(object):
         specs = {'pkg_manager': 'apt',
                  'check_urls': False,
                  'instructions': [
-                    ('base', 'ubuntu:xenial'),
-                    ('neurodebian', {'os_codename': 'xenial',
+                    ('base', 'debian:stretch'),
+                    ('neurodebian', {'os_codename': 'stretch',
                                     'download_server': 'usa-nh',
-                                    'full': False,
+                                    'full': True,
                                     'pkgs': ['dcm2niix']}),
                     ('user', 'neuro'),
                 ]}

--- a/neurodocker/interfaces/tests/test_spm.py
+++ b/neurodocker/interfaces/tests/test_spm.py
@@ -14,7 +14,8 @@ class TestSPM(object):
                  'check_urls': True,
                  'instructions': [
                     ('base', 'centos:7'),
-                    ('spm', {'version': '12', 'matlab_version': 'R2017a'})
+                    ('spm', {'version': '12', 'matlab_version': 'R2017a'}),
+                    ('user', 'neuro'),
                  ]}
         container = utils.get_container_from_specs(specs, working_dir='/home')
 

--- a/neurodocker/interfaces/tests/test_spm.py
+++ b/neurodocker/interfaces/tests/test_spm.py
@@ -17,11 +17,11 @@ class TestSPM(object):
                     ('spm', {'version': '12', 'matlab_version': 'R2017a'}),
                     ('user', 'neuro'),
                  ]}
-        container = utils.get_container_from_specs(specs, working_dir='/home')
+        container = utils.get_container_from_specs(specs)
 
-        cmd = ["/bin/sh", "-c", """echo 'fprintf("desired output")' > test.m """]
+        cmd = ["/bin/bash", "-c", """echo 'fprintf("desired output")' > /tmp/test.m """]
         container.exec_run(cmd)
-        cmd = ["/bin/sh", "-c", "$SPMMCRCMD test.m"]
+        cmd = ["/bin/bash", "-c", "$SPMMCRCMD /tmp/test.m"]
         output = container.exec_run(cmd)
         assert "error" not in output.lower(), "error running SPM command"
         assert "desired output" in output, "expected output not found"

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -65,8 +65,10 @@ def _add_generate_arguments(parser):
                         "format KEY=VALUE.", type=list_of_kv)
     p.add_argument('-u', '--user', action=OrderedArgs,
                    help="Set the user. If not set, user is root.")
-    p.add_argument('--ports', dest="expose", nargs="+",
-                   help="Port(s) to expose.", action=OrderedArgs)
+    p.add_argument('--expose', nargs="+", action=OrderedArgs,
+                   help="Port(s) to expose.")
+    p.add_argument('--workdir', action=OrderedArgs,
+                   help="Working directory in container")
 
     # Other arguments (no order).
     p.add_argument('-o', '--output', dest="output",

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -111,7 +111,7 @@ def _add_generate_arguments(parser):
         "neurodebian": (
             "Add NeuroDebian repository and optionally install NeuroDebian"
             " packages. Valid keys are os_codename (required; e.g., 'zesty'),"
-            " download_server (required), full (if false, default, use libre"
+            " download_server (required), full (if true, default, use non-free"
             " packages), and pkgs (list of packages to install). Valid"
             " download servers are {}.".format(_ndeb_servers)),
         "spm": (

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -30,7 +30,12 @@ class OrderedArgs(Action):
 def _add_generate_arguments(parser):
     """Add arguments to `parser` for sub-command `generate`."""
     p = parser
-    list_of_kv = lambda kv: kv.split("=")
+
+    def list_of_kv(kv):
+        """Split string `kv` at first equals sign."""
+        l = kv.split("=")
+        l[1:] = ["=".join(l[1:])]
+        return l
 
     p.add_argument("-b", "--base", required=True,
                             help="Base Docker image. Eg, ubuntu:17.04")
@@ -92,9 +97,10 @@ def _add_generate_arguments(parser):
             " commit."),
         "freesurfer": (
             "Install FreeSurfer. Valid keys are version (required),"
-            " license_path (relative path to license), and use_binaries"
-            " (default true). A FreeSurfer license is required to run the"
-            " software and is not provided by Neurodocker."),
+            " license_path (relative path to license), min (if true, install"
+            " binaries minimized for recon-all) and use_binaries (default true"
+            "). A FreeSurfer license is required to run the software and is not"
+            " provided by Neurodocker."),
         "fsl": (
             "Install FSL. Valid keys are version (required), use_binaries"
             " (default true) and use_installer."),

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -46,7 +46,7 @@ def test_dockerfile_opts(capsys):
     assert 'ENV KEY="VAL" \\' in out
     assert '  KEY2="VAL"' in out
 
-    main(args.format('--port 1230 1231').split())
+    main(args.format('--expose 1230 1231').split())
     out, _ = capsys.readouterr()
     assert "EXPOSE 1230 1231" in out
 

--- a/neurodocker/utils.py
+++ b/neurodocker/utils.py
@@ -27,7 +27,7 @@ def _string_vals_to_bool(dictionary):
     import re
 
     bool_vars = ['use_binaries', 'use_installer', 'use_neurodebian',
-                 'add_to_path']
+                 'add_to_path', 'min']
 
     if dictionary is None:
         return


### PR DESCRIPTION
fixes #61 #62 

- free permissions to /opt for non-root users.
- add the directory /neurodocker with a default entrypoint bash script `startup.sh`.
  - add the appropriate `source ...` command to `/neurodocker/startup.sh` for freesurfer and fsl.
- add support for minimized freesurfer.
- add mention of fsl's non-free license.
- make non-free sources the default for neurodebian.