### PR TITLE
FIX: source SPMMCRCMD in entrypoint for singularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ _Neurodocker_ is a Python project that generates custom Dockerfiles for neuroima
 
 Examples:
   - Command-line
-    - [Generate Dockerfile (with project's Docker image)](#generate-dockerfile-with-projects-docker-image)
-    - [Generate Dockerfile (without project's Docker image)](#generate-dockerfile-without-projects-docker-image)
+    - [Generate Dockerfile (with project's Docker image)](#generate-dockerfile)
+    - [Generate Dockerfile (without project's Docker image)](#generate-dockerfile-full)
   - In a Python script
     - [Generate Dockerfile, build Docker image, run commands in image (minimal)](#generate-dockerfile-build-docker-image-run-commands-in-image-minimal)
     - [Generate full Dockerfile](#generate-full-dockerfile)
@@ -68,14 +68,14 @@ Valid options for each software package are the keyword arguments for the class 
 |                 | full | If true (default), use non-free sources. If false, use libre sources. |
 
 
-\* denotes required argument.
+\* required argument.
 
 ** FSL is non-free. If you are considering commercial use of FSL, please consult the [relevant license](https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence).
 
 
 # Examples
 
-## Generate Dockerfile (with project's Docker image)
+## Generate Dockerfile
 
 Generate Dockerfile, and print result to stdout. The result can be piped to `docker build` to build the Docker image.
 
@@ -85,7 +85,7 @@ docker run --rm kaczmarj/neurodocker generate -b ubuntu:17.04 -p apt --ants vers
 docker run --rm kaczmarj/neurodocker generate -b ubuntu:17.04 -p apt --ants version=2.2.0 | docker build -
 ```
 
-## Generate Dockerfile (without project's Docker image)
+## Generate Dockerfile (full)
 
 In this example, a Dockerfile is generated with all of the software that _Neurodocker_ supports, and the Dockerfile is saved to disk. The order in which the arguments are given is preserved in the Dockerfile. The saved Dockerfile can be passed to `docker build`.
 
@@ -99,18 +99,27 @@ docker run --rm kaczmarj/neurodocker generate \
 --freesurfer version=6.0.0 min=true \
 --fsl version=5.0.10 \
 --user=neuro \
---miniconda env_name=default python_version=3.5.1 conda_install="traits pandas" pip_install=nipype \
---miniconda env_name=py27 python_version=2.7 add_to_path=false \
+--miniconda env_name=default \
+            python_version=3.5.1 \
+            conda_install="traits pandas" \
+            pip_install="nipype" \
+--miniconda env_name=py27 \
+            python_version=2.7 \
+            add_to_path=false \
 --user=root \
 --mrtrix3 \
---neurodebian os_codename="jessie" download_server="usa-nh" pkgs="dcm2niix" \
+--neurodebian os_codename="jessie" \
+              download_server="usa-nh" \
+              pkgs="dcm2niix git-annex-standalone" \
 --spm version=12 matlab_version=R2017a \
 --user=neuro \
 --env KEY_A=VAL_A KEY_B=VAL_B \
 --env KEY_C="based on \$KEY_A" \
---instruction='RUN echo hello world' \
+--instruction='RUN mkdir /opt/mydir' \
+--add-to-entrypoint 'echo hello world' 'source myfile.sh' \
 --workdir /home/neuro \
---no-check-urls -o examples/generated-full.Dockerfile
+--no-check-urls \
+-o examples/generated-full.Dockerfile
 
 # Build Docker image using the saved Dockerfile.
 docker build -t myimage -f generated-full.Dockerfile examples

--- a/neurodocker/interfaces/fsl.py
+++ b/neurodocker/interfaces/fsl.py
@@ -119,6 +119,8 @@ class FSL(object):
         """Return Dockerfile instructions to install FSL using binaries hosted
         on FSL's website.
         """
+        from neurodocker.dockerfile import _add_to_entrypoint
+
         cmd = ('echo "Downloading FSL ..."'
                '\n&& curl -sSL {}'
                '\n| tar zx -C /opt'.format(url))
@@ -127,11 +129,12 @@ class FSL(object):
             fsl_python = "/opt/fsl/etc/fslconf/fslpython_install.sh"
             cmd +=  "\n&& /bin/bash {} -q -f /opt/fsl".format(fsl_python)
 
-        cmd += ("\n&& sed -i '$iecho Some packages in this Docker container are non-free' $ND_ENTRYPOINT"
-                "\n&& sed -i '$iecho If you are considering commercial use of"
-                " this container, please consult the relevant license:' $ND_ENTRYPOINT"
-                "\n&& sed -i '$iecho https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence' $ND_ENTRYPOINT"
-                "\n&& sed -i '$isource $FSLDIR/etc/fslconf/fsl.sh' $ND_ENTRYPOINT")
+        ent_cmds = ["echo Some packages in this Docker container are non-free",
+                    ("echo If you are considering commercial use of this"
+                     " container, please consult the relevant license:"),
+                     "echo https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence",
+                     "source $FSLDIR/etc/fslconf/fsl.sh",]
+        cmd += "\n&& {}".format(_add_to_entrypoint(ent_cmds, with_run=False))
         cmd = indent("RUN", cmd)
 
         env_cmd = ("FSLDIR=/opt/fsl"

--- a/neurodocker/interfaces/tests/test_miniconda.py
+++ b/neurodocker/interfaces/tests/test_miniconda.py
@@ -11,9 +11,9 @@ class TestMiniconda(object):
     """Tests for Miniconda class."""
 
     #@pytest.mark.skip(reason="running container in background does not find correct Python")
-    def test_build_image_miniconda_latest_shellscript_xenial(self):
+    def test_build_image_miniconda_latest_shellscript_centos7(self):
         """Install latest version of Miniconda via ContinuumIO's installer
-        script on Ubuntu Xenial.
+        script on CentOS 7.
         """
         specs = {'pkg_manager': 'yum',
                  'check_urls': True,

--- a/neurodocker/interfaces/tests/test_spm.py
+++ b/neurodocker/interfaces/tests/test_spm.py
@@ -8,12 +8,12 @@ from neurodocker.interfaces.tests import utils
 class TestSPM(object):
     """Tests for SPM class."""
 
-    def test_build_image_spm_12_standalone_centos7(self):
+    def test_build_image_spm_12_standalone_stretch(self):
         """Install standalone SPM12 and MATLAB MCR R2017a."""
-        specs = {'pkg_manager': 'yum',
+        specs = {'pkg_manager': 'apt',
                  'check_urls': True,
                  'instructions': [
-                    ('base', 'centos:7'),
+                    ('base', 'debian:stretch'),
                     ('spm', {'version': '12', 'matlab_version': 'R2017a'}),
                     ('user', 'neuro'),
                  ]}

--- a/neurodocker/interfaces/tests/test_spm.py
+++ b/neurodocker/interfaces/tests/test_spm.py
@@ -21,7 +21,11 @@ class TestSPM(object):
 
         cmd = ["/bin/bash", "-c", """echo 'fprintf("desired output")' > /tmp/test.m """]
         container.exec_run(cmd)
-        cmd = ["/bin/bash", "-c", "$SPMMCRCMD /tmp/test.m"]
+        # QUESTION: how can we run the entrypoint on a container in the
+        # background? The cmd below is a workaround because the entrypoint is
+        # not being run, so SPMMCRCMD is not set.
+        cmd = ["/bin/bash", "-c",
+               'source /neurodocker/startup.sh true && $SPMMCRCMD /tmp/test.m']
         output = container.exec_run(cmd)
         assert "error" not in output.lower(), "error running SPM command"
         assert "desired output" in output, "expected output not found"

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -60,6 +60,9 @@ def _add_generate_arguments(parser):
                            "multiple times. Added to end of Dockerfile."))
     p.add_argument('--entrypoint', action=OrderedArgs,
                    help="Entrypoint for the Docker image.")
+    p.add_argument('--add-to-entrypoint', action=OrderedArgs, nargs="+",
+                   help=("Add a command to the container's entrypoint"
+                         " (/neurodocker/startup.sh)"))
     p.add_argument('-e', '--env', action=OrderedArgs, nargs="+",
                    help="Environment variables to set in Docker image. Use the "
                         "format KEY=VALUE.", type=list_of_kv)


### PR DESCRIPTION
Singularity throws a "bad variable name" error when given an environment variable with spaces. Related to singularityware/singularity#719.

Also adds the option `--add-to-entrypoint` which allows users to add bash commands to the entrypoint more easily.