### PR TITLE
FIX+ENH: fix whiteout file issue + add cli options conda_opts and pip_opts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@ __pycache__
 .cache
 .DS_Store
 .ipynb_checkpoints
-/dockerfile_tests
+dockerfile_tests
+*.egg-info
 
 *.ipynb
 *.pyc

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ docker run --rm kaczmarj/neurodocker generate \
 --user=neuro \
 --miniconda env_name=default \
             python_version=3.5.1 \
-            conda_opts="--channel vida-nyu"
+            conda_opts="--channel vida-nyu" \
             conda_install="numpy pandas reprozip traits" \
             pip_install="nipype" \
 --miniconda env_name=py27 \

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ _Neurodocker_ is a Python project that generates custom Dockerfiles for neuroima
 
 Examples:
   - Command-line
-    - [Generate Dockerfile (with project's Docker image)](#generate-dockerfile)
-    - [Generate Dockerfile (without project's Docker image)](#generate-dockerfile-full)
+    - [Generate Dockerfile](#generate-dockerfile)
+    - [Generate Dockerfile (full)](#generate-dockerfile-full)
   - In a Python script
     - [Generate Dockerfile, build Docker image, run commands in image (minimal)](#generate-dockerfile-build-docker-image-run-commands-in-image-minimal)
     - [Generate full Dockerfile](#generate-full-dockerfile)
@@ -58,6 +58,8 @@ Valid options for each software package are the keyword arguments for the class 
 |               | python_version* | Version of Python. |
 |               | conda_install | Packages to install with conda. e.g., `conda_install="numpy traits"` |
 |               | pip_install | Packages to install with pip. |
+|               | conda_opts  | Command-line options to pass to [`conda create`](https://conda.io/docs/commands/conda-create.html). e.g., `conda_opts="-c vida-nyu"` |
+|               | pip_opts    | Command-line options to pass to [`pip install`](https://pip.pypa.io/en/stable/reference/pip_install/#options). |
 |               | add_to_path | If true (default), add this environment to $PATH. |
 |               | miniconda_version | Version of Miniconda. Latest by default. |
 | **MRtrix3** | use_binaries | If true (default), use pre-compiled binaries. If false, build from source. |
@@ -66,6 +68,8 @@ Valid options for each software package are the keyword arguments for the class 
 |                 | download_server* | Server to download NeuroDebian packages from. Choose the one closest to you. See `neurodocker generate --help` for the full list of servers. |
 |                 | pkgs | Packages to download from NeuroDebian. |
 |                 | full | If true (default), use non-free sources. If false, use libre sources. |
+| **SPM** | version        | 12 (earlier versions will be supported in the future). |
+|         | matlab_version | R2017a (other MCR versions will be supported once earlier SPM versions are supported). |
 
 
 \* required argument.
@@ -101,7 +105,8 @@ docker run --rm kaczmarj/neurodocker generate \
 --user=neuro \
 --miniconda env_name=default \
             python_version=3.5.1 \
-            conda_install="traits pandas" \
+            conda_opts="--channel vida-nyu"
+            conda_install="numpy pandas reprozip traits" \
             pip_install="nipype" \
 --miniconda env_name=py27 \
             python_version=2.7 \
@@ -117,9 +122,9 @@ docker run --rm kaczmarj/neurodocker generate \
 --env KEY_C="based on \$KEY_A" \
 --instruction='RUN mkdir /opt/mydir' \
 --add-to-entrypoint 'echo hello world' 'source myfile.sh' \
+--expose 8888 \
 --workdir /home/neuro \
---no-check-urls \
--o examples/generated-full.Dockerfile
+--no-check-urls > examples/generated-full.Dockerfile
 
 # Build Docker image using the saved Dockerfile.
 docker build -t myimage -f generated-full.Dockerfile examples

--- a/examples/generated-full.Dockerfile
+++ b/examples/generated-full.Dockerfile
@@ -5,7 +5,7 @@
 # pull request on our GitHub repository:
 #     https://github.com/kaczmarj/neurodocker
 #
-# Timestamp: 2017-08-04 13:15:02
+# Timestamp: 2017-08-10 11:22:38
 
 FROM debian:stretch
 
@@ -124,28 +124,26 @@ RUN echo "Downloading Miniconda installer ..." \
     && conda config --system --prepend channels conda-forge \
     && conda config --system --set auto_update_conda false \
     && conda config --system --set show_channel_urls true \
-    && conda update -y --all \
-    && conda clean -tipsy \
-    && find /opt/conda -name ".wh*" -exec rm {} +
+    && conda update -y -q --all && sync \
+    && conda clean -tipsy && sync
 
 #-------------------------
 # Create conda environment
 #-------------------------
-RUN conda create -y -q --name default python=3.5.1 \
-    	traits pandas \
-    && conda clean -tipsy \
+RUN conda create -y -q --name default --channel vida-nyu python=3.5.1 \
+    	numpy pandas reprozip traits \
+    && sync && conda clean -tipsy && sync \
     && /bin/bash -c "source activate default \
     	&& pip install -q --no-cache-dir \
     	nipype" \
-    && find /opt/conda -name ".wh*" -exec rm {} +
+    && sync
 ENV PATH=/opt/conda/envs/default/bin:$PATH
 
 #-------------------------
 # Create conda environment
 #-------------------------
 RUN conda create -y -q --name py27 python=2.7 \
-    && conda clean -tipsy \
-    && find /opt/conda -name ".wh*" -exec rm {} +
+    && sync && conda clean -tipsy && sync
 
 USER root
 
@@ -215,4 +213,7 @@ RUN mkdir /opt/mydir
 RUN sed -i '$iecho hello world' $ND_ENTRYPOINT \
     && sed -i '$isource myfile.sh' $ND_ENTRYPOINT
 
+EXPOSE 8888
+
 WORKDIR /home/neuro
+

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -112,9 +112,10 @@ def _add_generate_arguments(parser):
         "miniconda": (
             "Install Miniconda. Valid keys are env_name (required),"
             " python_version (required), conda_install, pip_install,"
-            " add_to_path (default true) and miniconda_version (defaults to"
-            " latest). The options conda_install and pip_install accept"
-            ' strings of packages: conda_install="traits numpy".'),
+            " conda_opts, pip_opts, add_to_path (default true) and"
+            " miniconda_version (defaults to latest). The options conda_install"
+            " and pip_install accept strings of packages:"
+            ' conda_install="traits numpy".'),
         "mrtrix3": (
             "Install MRtrix3. Valid keys are use_binaries (default true) and"
             " git_hash. If git_hash is specified and use_binaries is false,"


### PR DESCRIPTION
AUFS whiteout file fix related to poldracklab/fmriprep#651 and singularityware/singularity#571.

Also adds the command-line options `conda_opts` and `pip_opts`, where the user can supply command-line options to `conda create` and `pip install`.

```shell
neurodocker generate -b debian:stretch -p apt \
--user=neuro \
--miniconda env_name=default \
            python_version=3.5.1 \
            conda_install="numpy pandas reprozip traits" \
            conda_opts="--channel vida-nyu" \
            pip_install="nipype" \
            pip_opts="--no-deps"
```