### PR TITLE
FIX: dockerfile entrypoint + secret env vars in travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,9 @@ script:
     else
     travis_wait 50 python -m pytest -v -k "test_build_image_$INTERFACE_TO_BUILD" --cov=./ neurodocker;
     fi }
-  - docker login -u $DOCKER_USER -p $DOCKER_PASS
+  - if [ ! -z "$DOCKER_PASS" ]; then
+    docker login -u $DOCKER_USER -p $DOCKER_PASS;
+    fi
   - run_tests
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/neurodocker/dockerfile.py
+++ b/neurodocker/dockerfile.py
@@ -211,10 +211,8 @@ def _add_common_dependencies(pkg_manager):
                "\n# Install common dependencies and create default entrypoint"
                "\n#----------------------------------------------------------")
 
-
-
     env = ('LANG="C.UTF-8"'
-           '\nLC_ALL="C"'
+           '\nLC_ALL="C.UTF-8"'
            '\nND_ENTRYPOINT="{}"'.format(ENTRYPOINT_FILE))
     env = indent("ENV", env)
 
@@ -222,10 +220,12 @@ def _add_common_dependencies(pkg_manager):
     cmd = cmd.format(pkgs=deps)
 
     cmd += ("\n&& chmod 777 /opt && chmod a+s /opt"
-            "\n&& mkdir /neurodocker"
-            "\n&& echo '#!/usr/bin/env bash' >> $ND_ENTRYPOINT"
-            "\n&& echo 'set +x' >> $ND_ENTRYPOINT"
-            "\n&& echo 'if [ -z \"$*\" ]; then /usr/bin/env bash; else $*; fi' >> $ND_ENTRYPOINT"
+            "\n&& mkdir -p /neurodocker"
+            '\n&& if [ ! -f "$ND_ENTRYPOINT" ]; then'
+            "\n     echo '#!/usr/bin/env bash' >> $ND_ENTRYPOINT"
+            "\n     && echo 'set +x' >> $ND_ENTRYPOINT"
+            "\n     && echo 'if [ -z \"$*\" ]; then /usr/bin/env bash; else $*; fi' >> $ND_ENTRYPOINT;"
+            "\n   fi"
             "\n&& chmod -R 777 /neurodocker && chmod a+s /neurodocker")
     cmd = indent("RUN", cmd)
     entrypoint = 'ENTRYPOINT ["{}"]'.format(ENTRYPOINT_FILE)

--- a/neurodocker/interfaces/neurodebian.py
+++ b/neurodocker/interfaces/neurodebian.py
@@ -92,7 +92,8 @@ class NeuroDebian(object):
                "\n&& {clean}"
                "\n&& curl -sSL {url}"
                "\n> /etc/apt/sources.list.d/neurodebian.sources.list"
-               "\n&& apt-key adv --fetch-keys https://dl.dropbox.com/s/zxs209o955q6vkg/neurodebian.gpg"
+               "\n&& curl -sSL https://dl.dropbox.com/s/zxs209o955q6vkg/neurodebian.gpg"
+               "\n| apt-key add -"
                # Syntax from
                # https://github.com/poldracklab/fmriprep/blob/master/Dockerfile#L21
                "\n&& (apt-key adv --refresh-keys --keyserver"

--- a/neurodocker/interfaces/tests/test_neurodebian.py
+++ b/neurodocker/interfaces/tests/test_neurodebian.py
@@ -11,14 +11,12 @@ from neurodocker.interfaces.tests import utils
 class TestNeuroDebian(object):
     """Tests for NeuroDebian class."""
 
-    def test_build_image_neurodebian_dcm2niix_stretch(self):
-        """Install latest version of Miniconda via ContinuumIO's installer
-        script on Debian Stretch.
-        """
+    def test_build_image_neurodebian_dcm2niix_xenial(self):
+        """Install NeuroDebian on Ubuntu 16.04."""
         specs = {'pkg_manager': 'apt',
                  'check_urls': False,
                  'instructions': [
-                    ('base', 'debian:stretch'),
+                    ('base', 'ubuntu:16.04'),
                     ('neurodebian', {'os_codename': 'stretch',
                                     'download_server': 'usa-nh',
                                     'full': True,

--- a/neurodocker/interfaces/tests/utils.py
+++ b/neurodocker/interfaces/tests/utils.py
@@ -99,20 +99,20 @@ def push_image(name):
 def _get_dbx_token():
     """Get access token for Dopbox API."""
     import os
+    import warnings
 
     try:
-         return os.environ['DROPBOX_TOKEN']
+        return os.environ['DROPBOX_TOKEN']
     except KeyError:
-        raise Exception("Environment variable not found: DROPBOX_TOKEN."
-                        " Cannot interact with Dropbox API.")
+        warnings.warn("Environment variable not found: DROPBOX_TOKEN."
+                      " Cannot interact with Dropbox API. Cannot compare "
+                      " Dockerfiles. Will pull existing Docker images ...")
+        return None
 
 
 def _check_can_push():
     """Raise error if user cannot push to DockerHub."""
     pass
-
-
-dbx_client = memory.Dropbox(_get_dbx_token())
 
 
 def get_image_from_memory(df, remote_path, name, force_build=False):
@@ -123,7 +123,20 @@ def get_image_from_memory(df, remote_path, name, force_build=False):
         logger.info("Building image (forced) ... Result should be pushed.")
         image = build_image(df, name)
         push = True
-    elif memory.should_build_image(df, remote_path, remote_object=dbx_client):
+        return image, push
+
+    token = _get_dbx_token()
+
+    # Take into account other forks of the project. They cannot use the secret
+    # environment variables in travis ci (e.g., the dropbox token).
+    if token is None:
+        image = pull_image(name)
+        push = False
+        return image, push
+
+    dbx_client = memory.Dropbox()
+
+    if memory.should_build_image(df, remote_path, remote_object=dbx_client):
         logger.info("Building image... Result should be pushed.")
         image = build_image(df, name)
         push = True

--- a/neurodocker/interfaces/tests/utils.py
+++ b/neurodocker/interfaces/tests/utils.py
@@ -134,7 +134,7 @@ def get_image_from_memory(df, remote_path, name, force_build=False):
         push = False
         return image, push
 
-    dbx_client = memory.Dropbox()
+    dbx_client = memory.Dropbox(token)
 
     if memory.should_build_image(df, remote_path, remote_object=dbx_client):
         logger.info("Building image... Result should be pushed.")


### PR DESCRIPTION
1. Create `/neurodocker/startup.sh` only if it does not already exist. This will allow neurodocker images to inherit other neurodocker images.
2. Prevent unset secret environment variables from breaking the travis builds.