### PR TITLE
ADD: ability to create conda env from yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Valid options for each software package are the keyword arguments for the class 
 |           | use_installer | If true, use FSL's Python installer. Only valid on CentOS images. |
 | **MINC** | version* | 1.9.15 |
 | **Miniconda** | env_name* | Name of this conda environment. |
+|               | yaml_file | Environment specification file. Can be path on host or URL. |
 |               | conda_install | Packages to install with conda. e.g., `conda_install="python=3.6 numpy traits"` |
 |               | pip_install | Packages to install with pip. |
 |               | conda_opts  | Command-line options to pass to [`conda create`](https://conda.io/docs/commands/conda-create.html). e.g., `conda_opts="-c vida-nyu"` |

--- a/neurodocker/utils.py
+++ b/neurodocker/utils.py
@@ -112,9 +112,19 @@ def _namespace_to_specs(namespace):
 
     specs = {'pkg_manager': namespace.pkg_manager,
              'check_urls': namespace.check_urls,
-             'instructions': instructions,}
+             'instructions': instructions, }
 
     return specs
+
+
+def is_url(string):
+    try:
+        from urllib.parse import urlparse  # Python 3
+    except ImportError:
+        from urlparse import urlparse  # Python 2
+
+    result = urlparse(string)
+    return (result.scheme and result.netloc)
 
 
 def check_url(url, timeout=5, **kwargs):


### PR DESCRIPTION
Closes #94 

Examples
----------

Can point to local file:
```
docker run --rm kaczmarj/neurodocker generate -b debian:stretch -p apt --miniconda env_name=neuro yaml_file=env.yml > Dockerfile
```

or to URL:
```
docker run --rm kaczmarj/neurodocker generate -b debian:stretch -p apt --miniconda env_name=neuro yaml_file=https://mysite.com/path/to/env.yml > Dockerfile
```
