### PR TITLE
Adds explicit tag to call to neurodocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This software is still in the early stages of development. If you come across an
 
 You can use _Neurodocker's_ Docker image, or you can install the project with `pip`:
 
-`docker run --rm kaczmarj/neurodocker --help`
+`docker run --rm kaczmarj/neurodocker:v0.3.1 --help`
 
 or
 


### PR DESCRIPTION
Since explicit tags were introduced (which is a good idea!), calls without a tag, will look for `latest`, and fail when failing to find that tag. This fixes that issue.