### PR TITLE
fix: replace add_to_path with activate + do not upgrade all root cond…

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Valid options for each software package are the keyword arguments for the class 
 |               | pip_install | Packages to install with pip. |
 |               | conda_opts  | Command-line options to pass to [`conda create`](https://conda.io/docs/commands/conda-create.html). e.g., `conda_opts="-c vida-nyu"` |
 |               | pip_opts    | Command-line options to pass to [`pip install`](https://pip.pypa.io/en/stable/reference/pip_install/#options). |
-|               | add_to_path | If true (default), add this environment to $PATH. |
+|               | activate | If true (default), activate this environment in container entrypoint. |
 |               | miniconda_version | Version of Miniconda. Latest by default. |
 | **MRtrix3** | use_binaries | If true (default), use pre-compiled binaries. If false, build from source. |
 |             | git_hash | Git hash to checkout to before building from source (only used if use_binaries is false). |

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -129,10 +129,10 @@ def _add_generate_arguments(parser):
             " (default true) and use_installer."),
         "miniconda": (
             "Install Miniconda. Valid keys are env_name (required),"
-            " conda_install, pip_install, conda_opts, pip_opts, add_to_path"
+            " conda_install, pip_install, conda_opts, pip_opts, activate"
             " (default false) and miniconda_version (defaults to latest). The"
-            " options conda_install and pip_install accept strings of packages:"
-            ' conda_install="python=3.6 numpy traits".'),
+            " options conda_install and pip_install accept strings of"
+            ' packages: conda_install="python=3.6 numpy traits".'),
         "mrtrix3": (
             "Install MRtrix3. Valid keys are use_binaries (default true) and"
             " git_hash. If git_hash is specified and use_binaries is false,"


### PR DESCRIPTION
…a packages

- Prepending the bin path of a conda environment to $PATH would lead to unexpected behavior. In some cases, packages would be installed to the root environment.
- Do not upgrade the packages in the root environment. This behavior is not reproducible. Related to this, consider setting miniconda_version to a specific version, instead of 'latest'.