### PR TITLE
Build afni from source

### DIFF
--- a/neurodocker/interfaces/afni.py
+++ b/neurodocker/interfaces/afni.py
@@ -192,6 +192,9 @@ class AFNI(object):
         source."""
         pkgs = self._get_source_dependencies()
 
+        if self.version == "latest":
+            self.version = "master"
+
         cmd = ("{install}"
                "".format(**manage_pkgs[self.pkg_manager]).format(pkgs=pkgs))
 
@@ -238,10 +241,7 @@ class AFNI(object):
 
         cmd = indent("RUN", cmd)
 
-        env_plugin_path = "AFNI_PLUGINPATH=/opt/afni"
-        env_plugin_path = indent("ENV", env_plugin_path)
-
-        env_cmd = "PATH=/opt/afni:$PATH"
+        env_cmd = "PATH=/opt/afni:$PATH AFNI_PLUGINPATH=/opt/afni"
         env_cmd = indent("ENV", env_cmd)
 
-        return "\n".join((env_cmd, env_plugin_path, cmd))
+        return "\n".join((env_cmd, cmd))


### PR DESCRIPTION
Added some bits to build AFNI from source.  It may require some refactoring.  To use it, you would have to pass these flags simultaneously: `use_binaries=false build_source=true`(see [here](https://github.com/giovtorres/neurodocker/blob/build_afni_source/neurodocker/interfaces/afni.py#L69-L72)).  Also, `version` in this context refers to the git branch, so `latest` is not valid.  How should this interface handle these?

Thanks.

/cc @Shotgunosine 