### PR TITLE
FIX: do not delete build dependencies in `dcm2niix`

### DIFF
--- a/neurodocker/interfaces/dcm2niix.py
+++ b/neurodocker/interfaces/dcm2niix.py
@@ -63,7 +63,6 @@ class Dcm2niix(object):
                "\n&& cmake .. && make"
                "\n&& make install"
                "\n&& rm -rf /tmp/*"
-               "\n&& {remove}"
                "".format(pkgs=pkgs[self.pkg_manager], url=url,
                          **manage_pkgs[self.pkg_manager]))
         cmd = cmd.format(pkgs='$deps')


### PR DESCRIPTION
Do not delete build dependencies after installing `dcm2niix`. This could delete packages that the user had installed previously.