### PR TITLE
ENH: miniconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Neurodocker
 
 [![build status](https://img.shields.io/circleci/project/github/kaczmarj/neurodocker/master.svg)](https://circleci.com/gh/kaczmarj/neurodocker/tree/master)
-[![build status](https://img.shields.io/docker/pulls/kaczmarj/neurodocker.svg)](https://hub.docker.com/r/kaczmarj/neurodocker/)
-[![build status](https://img.shields.io/pypi/pyversions/neurodocker.svg)](https://pypi.org/project/neurodocker/)
+[![docker pulls](https://img.shields.io/docker/pulls/kaczmarj/neurodocker.svg)](https://hub.docker.com/r/kaczmarj/neurodocker/)
+[![python versions](https://img.shields.io/pypi/pyversions/neurodocker.svg)](https://pypi.org/project/neurodocker/)
 
 _Neurodocker_ is a command-line program that generates custom Dockerfiles and Singularity recipes for neuroimaging and minifies existing containers.
 
@@ -79,7 +79,8 @@ Note: it is not yet possible to minimize Docker containers using the _Neurodocke
 |          | install_path | Installation path. Default `/opt/minc-{version}`. |
 | **Miniconda** | version | latest (default), all other hosted versions. |
 |               | install_path | Installation path. Default `/opt/miniconda-{version}`. |
-|               | env_name* | Name of this conda environment. |
+|               | create_env | Name of conda environment to create. |
+|               | use_env | Name of previously installed environment. |
 |               | conda_install | Packages to install with `conda`. E.g., `conda_install="python=3.6 numpy traits"` |
 |               | pip_install | Packages to install with `pip`. |
 |               | activate | If true (default), activate this environment in container entrypoint. |

--- a/neurodocker/generators/singularity.py
+++ b/neurodocker/generators/singularity.py
@@ -163,7 +163,9 @@ class SingularityRecipe(ContainerSpecGenerator):
                 if impl in _installation_implementations.values():
                     interface = impl(pkg_manager=pkg_man, **params)
                     if interface.env:
-                        self._environment.update(**interface.render_env())
+                        _this_env = interface.render_env()
+                        if _this_env is not None:
+                            self._environment.update(**_this_env)
                     if interface.run:
                         self._post.append(interface.render_run())
                 else:

--- a/neurodocker/interfaces/interfaces.py
+++ b/neurodocker/interfaces/interfaces.py
@@ -226,8 +226,6 @@ class Miniconda(_BaseInterface):
         if not Miniconda._env_set:
             Miniconda._env_set = True
             return super().render_env()
-        else:
-            return {}
 
 
 class MRtrix3(_BaseInterface):

--- a/neurodocker/interfaces/interfaces.py
+++ b/neurodocker/interfaces/interfaces.py
@@ -226,6 +226,8 @@ class Miniconda(_BaseInterface):
         if not Miniconda._env_set:
             Miniconda._env_set = True
             return super().render_env()
+        else:
+            return {}
 
 
 class MRtrix3(_BaseInterface):

--- a/neurodocker/interfaces/tests/test_miniconda.py
+++ b/neurodocker/interfaces/tests/test_miniconda.py
@@ -14,7 +14,7 @@ class TestMiniconda(object):
                 (
                     'miniconda',
                     {
-                        'env_name': 'default',
+                        'create_env': 'default',
                         'conda_install': ['python=3.6.5', 'traits'],
                         'pip_install': ['nipype'],
                         'activate': True,
@@ -23,7 +23,7 @@ class TestMiniconda(object):
                 (
                     'miniconda',
                     {
-                        'env_name': 'default',
+                        'use_env': 'default',
                         'pip_install': ['pylsl'],
                     }
                 ),
@@ -43,7 +43,7 @@ class TestMiniconda(object):
                 (
                     'miniconda',
                     {
-                        'env_name': 'default',
+                        'create_env': 'default',
                         'conda_install': ['python=3.6.5', 'traits'],
                         'pip_install': ['nipype'],
                         'activate': True,
@@ -51,7 +51,7 @@ class TestMiniconda(object):
                 ),
                 (
                     'miniconda',
-                    {'env_name': 'default', 'pip_install': ['pylsl']}
+                    {'use_env': 'default', 'pip_install': ['pylsl']}
                 ),
             ],
         }

--- a/neurodocker/templates/miniconda.yaml
+++ b/neurodocker/templates/miniconda.yaml
@@ -25,11 +25,15 @@ generic:
       conda config --system --set show_channel_urls true
       sync && conda clean -tipsy && sync
       {% endif -%}
+      {% if miniconda.yaml_file -%}
+      conda env create {{ miniconda.conda_opts|default("-q") }} --name {{ miniconda.env_name }} --file {{ miniconda.yaml_file }}
+      rm -rf ~/.cache/pip/*
+      {% else -%}
       {% if miniconda.env_name not in miniconda._environments -%}
-      conda create -y -q --name {{ miniconda.env_name }}
+      conda create -y {{ miniconda.conda_opts|default("-q") }} --name {{ miniconda.env_name }}
       {% endif -%}
       {% if miniconda.conda_install is not none -%}
-      conda install -y -q --name {{ miniconda.env_name }} \
+      conda install -y {{ miniconda.conda_opts|default("-q") }} --name {{ miniconda.env_name }} \
       {%- for pkg in miniconda.conda_install %}
           {% if not loop.last -%}
           {{ pkg }} \
@@ -41,7 +45,7 @@ generic:
       {% endif -%}
       {% if miniconda.pip_install is not none -%}
       bash -c "source activate {{ miniconda.env_name }}
-        pip install -q --no-cache-dir \
+        pip install {{ miniconda.pip_opts }} --no-cache-dir \
         {%- for pkg in miniconda.pip_install %}
             {% if not loop.last -%}
             {{ pkg }} \
@@ -49,8 +53,10 @@ generic:
             {{ pkg }}
             {%- endif -%}
         {% endfor %}"
+      rm -rf ~/.cache/pip/*
       sync
       {% endif -%}
       {% if miniconda.activate -%}
       sed -i '$isource activate {{ miniconda.env_name }}' $ND_ENTRYPOINT
+      {% endif -%}
       {% endif -%}

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -108,14 +108,11 @@ def test_generate_from_json(capsys, tmpdir):
 
 def test_miniconda_env(capsys):
     """Test that environment is appropriately for Miniconda."""
-    base = "generate docker --base=debian:stretch --pkg-manager=apt "
-
-    main((base + "--miniconda create_env=foobar conda_install=foobar").split())
+    cmd = (
+        "generate docker --base=debian:stretch --pkg-manager=apt"
+        " --miniconda create_env=foobar conda_install=foobar"
+        " --miniconda use_env=foobar conda_install=foobaz")
+    main(cmd.split())
     out, _ = capsys.readouterr()
-    assert "CONDA_DIR" in out
-    assert "repo.continuum.io" in out
-
-    main((base + "--miniconda use_env=foobar conda_install=foobar").split())
-    out, _ = capsys.readouterr()
-    assert "CONDA_DIR" not in out
-    assert "repo.continuum.io" not in out
+    assert out.count("CONDA_DIR") == 1
+    assert out.count("repo.continuum.io") == 1

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -104,15 +104,3 @@ def test_generate_from_json(capsys, tmpdir):
     # saves to JSON (with timestamp).
     sl = slice(8, -19)
     assert true.split('\n')[sl] == test.split('\n')[sl]
-
-
-def test_miniconda_env(capsys):
-    """Test that environment is appropriately for Miniconda."""
-    cmd = (
-        "generate docker --base=debian:stretch --pkg-manager=apt"
-        " --miniconda create_env=foobar conda_install=foobar"
-        " --miniconda use_env=foobar conda_install=foobaz")
-    main(cmd.split())
-    out, _ = capsys.readouterr()
-    assert out.count("CONDA_DIR") == 1
-    assert out.count("repo.continuum.io") == 1

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -17,7 +17,7 @@ def test_generate():
         " --freesurfer version=6.0.0"
         " --fsl version=5.0.10"
         " --user=neuro"
-        " --miniconda env_name=neuro conda_install=python=3.6.2"
+        " --miniconda create_env=neuro conda_install=python=3.6.2"
         " --user=root"
         " --mrtrix3 version=3.0"
         " --neurodebian os_codename=zesty server=usa-nh"

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -104,3 +104,18 @@ def test_generate_from_json(capsys, tmpdir):
     # saves to JSON (with timestamp).
     sl = slice(8, -19)
     assert true.split('\n')[sl] == test.split('\n')[sl]
+
+
+def test_miniconda_env(capsys):
+    """Test that environment is appropriately for Miniconda."""
+    base = "generate docker --base=debian:stretch --pkg-manager=apt "
+
+    main((base + "--miniconda create_env=foobar conda_install=foobar").split())
+    out, _ = capsys.readouterr()
+    assert "CONDA_DIR" in out
+    assert "repo.continuum.io" in out
+
+    main((base + "--miniconda use_env=foobar conda_install=foobar").split())
+    out, _ = capsys.readouterr()
+    assert "CONDA_DIR" not in out
+    assert "repo.continuum.io" not in out


### PR DESCRIPTION
Fixes #147 

Breaking changes:
- replaces `env_name` and `preinstalled` with `create_env` and `use_env`.
  - `create_env` creates a new environment with `conda create`.
  - `use_env` assumes the environment already exists and installs things into it.

Adds ability to create conda environment from yaml file.
Fixes environment variable logic. Environment variables are included when necessary and at most once.