### PR TITLE
ENH+ADD: use centos6 mrtrix3 + add source option

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -304,7 +304,7 @@ neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=ap
 
 ```shell
 neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \
-  --mrtrix3 version=3.0
+  --mrtrix3 version=3.0_RC3
 ```
 
 ## NeuroDebian

--- a/neurodocker/interfaces/tests/test_mrtrix.py
+++ b/neurodocker/interfaces/tests/test_mrtrix.py
@@ -10,7 +10,7 @@ class TestMRtrix3(object):
             'pkg_manager': 'yum',
             'instructions': [
                 ('base', 'centos:7'),
-                ('mrtrix3', {'version': '3.0'}),
+                ('mrtrix3', {'version': '3.0_RC3'}),
                 ('user', 'neuro'),
             ],
         }
@@ -24,7 +24,7 @@ class TestMRtrix3(object):
             'pkg_manager': 'yum',
             'instructions': [
                 ('base', 'docker://centos:7'),
-                ('mrtrix3', {'version': '3.0'}),
+                ('mrtrix3', {'version': '3.0_RC2'}),
                 ('user', 'neuro'),
             ],
         }

--- a/neurodocker/templates/mrtrix3.yaml
+++ b/neurodocker/templates/mrtrix3.yaml
@@ -6,6 +6,9 @@
 
 generic:
   binaries:
+    depndencies:
+      apt: python python-numpy
+      yum: numpy python
     urls:
       "3.0_RC3": https://dl.dropbox.com/s/2oh339ehcxcf8xf/mrtrix3-3.0_RC3-Linux-centos6.9-x86_64.tar.gz
       "3.0_RC2": https://dl.dropbox.com/s/f6y0l472wuio70x/mrtrix3-3.0_RC2-Linux-centos6.9-x86_64.tar.gz
@@ -19,12 +22,10 @@ generic:
 
   source:
     dependencies:
-      apt: g++ gcc git python make zlib1g-dev
-      yum: gcc-c++ git python make zlib-devel
+      apt: g++ gcc git libeigen3-dev make python python-numpy zlib1g-dev
+      yum: eigen3-devel gcc-c++ git make numpy python zlib-devel
     env:
-      ANTSPATH: "{{ ants.install_path }}/bin"
-      PATH: "{{ ants.install_path }}/bin:$PATH"
-      LD_LIBRARY_PATH: "{{ ants.install_path }}/lib:$LD_LIBRARY_PATH"
+      PATH: "{{ mrtrix3.install_path }}/bin:$PATH"
     instructions: |
       {{ mrtrix3.install_dependencies() }}
       mkdir -p {{ mrtrix3.install_path }}
@@ -34,4 +35,5 @@ generic:
       git checkout {{ mrtrix3.version }}
       {% endif -%}
       ./configure -nogui
+      echo "Compiling MRtrix3 ..."
       ./build

--- a/neurodocker/templates/mrtrix3.yaml
+++ b/neurodocker/templates/mrtrix3.yaml
@@ -7,7 +7,8 @@
 generic:
   binaries:
     urls:
-      "3.0": https://dl.dropbox.com/s/2g008aaaeht3m45/mrtrix3-Linux-centos6.tar.gz
+      "3.0_RC3": https://dl.dropbox.com/s/2oh339ehcxcf8xf/mrtrix3-3.0_RC3-Linux-centos6.9-x86_64.tar.gz
+      "3.0_RC2": https://dl.dropbox.com/s/f6y0l472wuio70x/mrtrix3-3.0_RC2-Linux-centos6.9-x86_64.tar.gz
     env:
       PATH: "{{ mrtrix3.install_path }}/bin:$PATH"
     instructions: |
@@ -16,4 +17,21 @@ generic:
       curl {{ mrtrix3.curl_opts }} {{ mrtrix3.binaries_url }} \
       | tar -xz -C {{ mrtrix3.install_path }} --strip-components 1
 
-#TODO(kaczmarj): add option to build from source.
+  source:
+    dependencies:
+      apt: g++ gcc git python make zlib1g-dev
+      yum: gcc-c++ git python make zlib-devel
+    env:
+      ANTSPATH: "{{ ants.install_path }}/bin"
+      PATH: "{{ ants.install_path }}/bin:$PATH"
+      LD_LIBRARY_PATH: "{{ ants.install_path }}/lib:$LD_LIBRARY_PATH"
+    instructions: |
+      {{ mrtrix3.install_dependencies() }}
+      mkdir -p {{ mrtrix3.install_path }}
+      git clone https://github.com/MRtrix3/mrtrix3.git {{ mrtrix3.install_path }}
+      cd {{ mrtrix3.install_path }}
+      {% if mrtrix3.version != "master" and mrtrix3.version != "latest" -%}
+      git checkout {{ mrtrix3.version }}
+      {% endif -%}
+      ./configure -nogui
+      ./build

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -19,7 +19,7 @@ def test_generate():
         " --user=neuro"
         " --miniconda create_env=neuro conda_install=python=3.6.2"
         " --user=root"
-        " --mrtrix3 version=3.0"
+        " --mrtrix3 version=3.0_RC3"
         " --neurodebian os_codename=zesty server=usa-nh"
         " --spm12 version=r7219 matlab_version=R2017a"
         " --expose 1234 9000"


### PR DESCRIPTION
This PR uses mrtrix3 binaries that were compiled on centos 6 ([Dockerfile](https://github.com/kaczmarj/mrtrix3/commit/01ae29745268244e04d46a537397b2d2569e5875) and adds the option to build mrtrix3 from source.