### PR TITLE
the apt default option --no-install-recommends causes problems with cython

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,3 +284,5 @@ $ reprounzip docker setup neurodocker-reprozip.rpz test
   - Solution: do not use the `-t/--tty` flag, unless using the container interactively.
 - Attempting to rebuild into an existing Singularity image may raise an error.
   - Solution: remove the existing image or build a new image file.
+- The default apt --install option "--no-install-recommends" (that aims at minimizing container sizes) can cause a strange behaviour for cython inside the container
+  - Solution: use "--install apt_opts='--quiet' "

--- a/README.md
+++ b/README.md
@@ -285,4 +285,5 @@ $ reprounzip docker setup neurodocker-reprozip.rpz test
 - Attempting to rebuild into an existing Singularity image may raise an error.
   - Solution: remove the existing image or build a new image file.
 - The default apt --install option "--no-install-recommends" (that aims at minimizing container sizes) can cause a strange behaviour for cython inside the container
-  - Solution: use "--install apt_opts='--quiet' "
+  - Solution: use "--install apt_opts=`--quiet` "
+  - more information: [examples](examples#--install)

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,7 +72,15 @@ neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=ap
   --install git vim
 ```
 
-by default --install uses --no-install-recommends to minimize container sizes. In few cases this can lead to unexpected behaviours and one can try to build a container without this option.
+one can use apt_opts to set options for apt-get install and yum_opts to set options for yum install:
+
+```shell
+neurodocker generate [docker|singularity] --base=centos:7 --pkg-manager=yum \
+  --install yum_opts='--debug' git vim
+```
+
+
+By default --install apt_opts uses --no-install-recommends to minimize container sizes. In few cases this can lead to unexpected behaviours and one can try to build a container without this option.
 
 ```shell
 neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \

--- a/examples/README.md
+++ b/examples/README.md
@@ -72,6 +72,14 @@ neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=ap
   --install git vim
 ```
 
+by default --install uses --no-install-recommends to minimize container sizes. In few cases this can lead to unexpected behaviours and one can try to build a container without this option.
+
+```shell
+neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \
+  --install apt_opts='--quiet' git vim
+  ```
+
+
 ## `--entrypoint`
 
 This option sets the container's default entrypoint and applies to Docker and Singularity. It adds an `ENTRYPOINT` layer for Docker and replaces the `%runscript` section for Singularity.

--- a/neurodocker/interfaces/_base.py
+++ b/neurodocker/interfaces/_base.py
@@ -11,7 +11,7 @@ from neurodocker.utils import load_yaml
 GENERIC_VERSION = 'generic'
 
 apt_install = """apt-get update -qq
-apt-get install -y {{ apt_opts|default('-q --no-install-recommends', true) }} \\\
+apt-get install -y {{ apt_opts|default('-q --no-install-recommends', false) }} \\\
 {% for pkg in pkgs %}
     {% if not loop.last -%}
     {{ pkg }} \\\

--- a/neurodocker/interfaces/_base.py
+++ b/neurodocker/interfaces/_base.py
@@ -11,7 +11,7 @@ from neurodocker.utils import load_yaml
 GENERIC_VERSION = 'generic'
 
 apt_install = """apt-get update -qq
-apt-get install -y {{ apt_opts|default('-q --no-install-recommends', false) }} \\\
+apt-get install -y {{ apt_opts|default('-q', true) }} \\\
 {% for pkg in pkgs %}
     {% if not loop.last -%}
     {{ pkg }} \\\

--- a/neurodocker/interfaces/_base.py
+++ b/neurodocker/interfaces/_base.py
@@ -11,7 +11,7 @@ from neurodocker.utils import load_yaml
 GENERIC_VERSION = 'generic'
 
 apt_install = """apt-get update -qq
-apt-get install -y {{ apt_opts|default('-q', true) }} \\\
+apt-get install -y {{ apt_opts|default('-q --no-install-recommends', true) }} \\\
 {% for pkg in pkgs %}
     {% if not loop.last -%}
     {{ pkg }} \\\


### PR DESCRIPTION
I am not sure if changing this default is the best way of solving this problem, but when I use cython in my containers, the no-install-recommends option causes cython to fail, because of missing packages. I guess you had this option to reduce the size of containers?