### PR TITLE
change miniconda.yaml_file use

### DIFF
--- a/neurodocker/templates/miniconda.yaml
+++ b/neurodocker/templates/miniconda.yaml
@@ -26,7 +26,7 @@ generic:
       sync && conda clean -tipsy && sync
       {% endif -%}
       {% if miniconda.yaml_file -%}
-      conda env create {{ miniconda.conda_opts|default("-q") }} --name {{ miniconda.env_name }} --file {{ miniconda.yaml_file }}
+      conda create {{ miniconda.conda_opts|default("-q") }} --name {{ miniconda.env_name }} --file {{ miniconda.yaml_file }}
       rm -rf ~/.cache/pip/*
       {% else -%}
       {% if miniconda.env_name not in miniconda._environments -%}


### PR DESCRIPTION
I got an error message when using a .yml file defining my environment. 
When creating a miniconda environment, the syntax is `conda create --file X.yml`, instead of `conda env create --file X.yml`, see line 28-9
The syntax was correct in line 33 below, this edit makes them the same.