### PR TITLE
ENH: log ERROR with information about impl whenever specification is incorrectly specified

### DIFF
--- a/neurodocker/generators/singularity.py
+++ b/neurodocker/generators/singularity.py
@@ -13,6 +13,9 @@ from neurodocker.generators.common import ContainerSpecGenerator
 from neurodocker.generators.common import NEURODOCKER_ENTRYPOINT
 
 
+import logging
+logger = logging.getLogger(__name__)
+
 class _SingularityRecipeImplementations:
 
     def __init__(self, singularity_recipe_object):
@@ -161,7 +164,11 @@ class SingularityRecipe(ContainerSpecGenerator):
             if instruction in self._implementations.keys():
                 impl = self._implementations[instruction]
                 if impl in _installation_implementations.values():
-                    interface = impl(pkg_manager=pkg_man, **params)
+                    try:
+                        interface = impl(pkg_manager=pkg_man, **params)
+                    except Exception as exc:
+                        logger.error("Failed to instantiate %s: %s", impl, exc)
+                        raise
                     if interface.env:
                         _this_env = interface.render_env()
                         if _this_env is not None:


### PR DESCRIPTION
now it would look like

```shell
$> neurodocker generate singularity --base debian:stretch --pkg-manager apt --neurodebian datalad
[NEURODOCKER 2018-08-03 14:10:40,223 ERROR]: Failed to instantiate <class neurodocker.interfaces.interfaces.NeuroDebian>: __init__() missing 2 required positional arguments: os_codename and server
Traceback (most recent call last):
  File "/home/yoh/proj/repronim/neurodocker/venvs/dev3/bin/neurodocker", line 11, in <module>
    load_entry_point(neurodocker, console_scripts, neurodocker)()
  File "/home/yoh/proj/repronim/neurodocker/neurodocker/neurodocker.py", line 340, in main
    subparser_functions[namespace.subsubparser_name](namespace)
  File "/home/yoh/proj/repronim/neurodocker/neurodocker/neurodocker.py", line 293, in generate
    print(recipe_obj.render())
  File "/home/yoh/proj/repronim/neurodocker/neurodocker/generators/singularity.py", line 117, in render
    self._fill_parts()
  File "/home/yoh/proj/repronim/neurodocker/neurodocker/generators/singularity.py", line 168, in _fill_parts
    interface = impl(pkg_manager=pkg_man, **params)
TypeError: __init__() missing 2 required positional arguments: os_codename and server
```

So I would know that it was NeuroDebian specification which was wrong.
I on purpose avoided swalling/rethrowing another exception here so debugging
"on failure" could still get to the heart of the exception (which would not be
the case if I thrown a new one)