### PR TITLE
ADD: exclude_paths option to fsl

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ Note: it is not yet possible to minimize Docker containers using the _Neurodocke
 | **FreeSurfer** | version* | 6.0.0-min |
 |                | method | binaries (default) |
 |                | install_path | Installation path. Default `/opt/freesurfer-{version}`. |
-|                | exclude_paths | Sequence of path(s) to exclude when inflating the tarball. |
+|                | exclude_paths | Sequence of space-separated path(s) to exclude when inflating the tarball. |
 |                | license_path | Relative path to license file. If provided, this file will be copied into the Docker image. Must be within the build context. |
 | **FSL**** | version* | 5.0.11, 5.0.10, 5.0.9, 5.0.8 |
 |           | method | binaries (default) |
 |           | install_path | Installation path. Default `/opt/fsl-{version}`. |
+|           | exclude_paths | Sequence of space-separated path(s) to exclude when inflating the tarball. |
 | **Matlab Compiler Runtime** | version* | 2018a, 2012-17[a-b], 2010a |
 |                             | method | binaries (default) |
 |                             | install_path | Installation path. Default `/opt/matlabmcr-{version}`. |

--- a/neurodocker/interfaces/interfaces.py
+++ b/neurodocker/interfaces/interfaces.py
@@ -105,9 +105,10 @@ class FreeSurfer(_BaseInterface):
         else:
             self.exclude_paths = FreeSurfer._exclude_paths
 
-        self.exclude_paths = tuple(
-            posixpath.join('freesurfer', path) for path in self.exclude_paths
-        )
+        if self.exclude_paths:
+            self.exclude_paths = tuple(
+                posixpath.join('freesurfer', path)
+                for path in self.exclude_paths)
 
 
 class FSL(_BaseInterface):
@@ -118,6 +119,16 @@ class FSL(_BaseInterface):
 
     def __init__(self, *args, **kwargs):
         super().__init__(self._name, *args, **kwargs)
+
+        if hasattr(self, 'exclude_paths'):
+            if isinstance(self.exclude_paths, str):
+                self.exclude_paths = self.exclude_paths.split()
+        else:
+            self.exclude_paths = tuple()
+
+        if self.exclude_paths:
+            self.exclude_paths = tuple(
+                posixpath.join('fsl', path) for path in self.exclude_paths)
 
 
 class MatlabMCR(_BaseInterface):

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -111,12 +111,11 @@ def _add_generate_common_arguments(parser):
         "dcm2niix": "Install dcm2niix. Valid keys are version, method,"
                     " install_path, cmake_opts, and make_opts",
         "freesurfer": "Install FreeSurfer. Valid keys are version (required),"
-                      " method, install_path, exclude_paths, and license_path"
-                      " (relative path to license). A FreeSurfer license is"
-                      " required to run the software and is not provided by"
-                      " Neurodocker.",
-        "fsl": "Install FSL. Valid keys are version (required), method, and"
-               " install_path.",
+                      " method, install_path, and exclude_paths. A FreeSurfer"
+                      " license is required to run the software and is not"
+                      " provided by Neurodocker.",
+        "fsl": "Install FSL. Valid keys are version (required), method,"
+               " install_path, and exclude_paths.",
         "matlabmcr": "Install Matlab Compiler Runtime. Valid keys are version,"
                      " method, and install_path",
         "miniconda": "Install Miniconda. Valid keys are install_path,"

--- a/neurodocker/templates/fsl.yaml
+++ b/neurodocker/templates/fsl.yaml
@@ -26,7 +26,15 @@ generic:
       echo "Downloading FSL ..."
       mkdir -p {{ fsl.install_path }}
       curl {{ fsl.curl_opts }} {{ fsl.binaries_url }} \
-      | tar -xz -C {{ fsl.install_path }} --strip-components 1
+      | tar -xz -C {{ fsl.install_path }} --strip-components 1 {% if fsl.exclude_paths -%}\
+      {%- for exclude_path in fsl.exclude_paths %}
+        {% if not loop.last -%}
+        --exclude='{{ exclude_path }}' \
+        {%- else -%}
+        --exclude='{{ exclude_path }}'
+        {%- endif -%}
+      {%- endfor %}
+      {%- endif %}
       sed -i '$iecho Some packages in this Docker container are non-free' $ND_ENTRYPOINT
       sed -i '$iecho If you are considering commercial use of this container, please consult the relevant license:' $ND_ENTRYPOINT
       sed -i '$iecho https://fsl.fmrib.ox.ac.uk/fsl/fslwiki/Licence' $ND_ENTRYPOINT


### PR DESCRIPTION
Fixes #209 

this PR adds the option `exclude_paths` to `--fsl`. this allows users to exclude specified directories during the tar extraction step. paths must be separated by spaces.

for example, the command below will exclude the `docs` and `config` directories of fsl.

```shell
neurodocker generate docker \
    -b debian:stretch -p apt \
    --fsl version=5.0.11 exclude_paths='docs config'
```