### PR TITLE
fix @global_parse command not found error

### DIFF
--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -37,7 +37,7 @@ generic:
       curl {{ afni.curl_opts }} {{ afni.binaries_url }} \
       | tar -xz -C {{ afni.install_path }} --strip-components 1
       {%- if afni.install_r_pkgs %}
-      export PATH=$PATH:{{ afni.install_path }}  && rPkgsInstall -pkgs ALL
+      PATH=$PATH:{{ afni.install_path }}  && rPkgsInstall -pkgs ALL
       {% endif -%}
 
   source:

--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -37,7 +37,7 @@ generic:
       curl {{ afni.curl_opts }} {{ afni.binaries_url }} \
       | tar -xz -C {{ afni.install_path }} --strip-components 1
       {%- if afni.install_r_pkgs %}
-      {{ afni.install_path }}/rPkgsInstall -pkgs ALL
+      export PATH=$PATH:{{ afni.install_path }}  && rPkgsInstall -pkgs ALL
       {% endif -%}
 
   source:

--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -37,7 +37,7 @@ generic:
       curl {{ afni.curl_opts }} {{ afni.binaries_url }} \
       | tar -xz -C {{ afni.install_path }} --strip-components 1
       {%- if afni.install_r_pkgs %}
-      PATH=$PATH:{{ afni.install_path }}  && rPkgsInstall -pkgs ALL
+      PATH=$PATH:{{ afni.install_path }} rPkgsInstall -pkgs ALL
       {% endif -%}
 
   source:


### PR DESCRIPTION
I was running into an error when trying to install R packages for afni. The ``rPkgInstall`` command depends on ``@global_parse``, which has to be on the ``$PATH`` when ``rPkgInstall`` is run. Is there a better way to do this? This fix solved the problem for me.