### PR TITLE
enh: add desktop manager when installing vnc

### DIFF
--- a/neurodocker/templates/vnc.yaml
+++ b/neurodocker/templates/vnc.yaml
@@ -3,8 +3,8 @@
 generic:
   system:
     dependencies:
-      apt: tightvncserver xfonts-base xvfb
-      yum: tightvnc-server xorg-x11-fonts xorg-x11-server-Xvfb
+      apt: tightvncserver xfonts-base xvfb xterm openbox
+      yum: tightvnc-server xorg-x11-fonts xorg-x11-server-Xvfb xterm openbox
     instructions: |
       {{ vnc.install_dependencies() }}
       echo 'Configuring VNC password ...'


### PR DESCRIPTION
this won't solve matlab issue (see #210), but likely better for people who want a desktop.  we should check how well this works with singularity and on centos. do the tests cover this?