### PR TITLE
ENH: JSON output + examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,7 @@ jobs:
           name: Test examples in /examples directory
           command: |
             source ~/.bashrc
-            cd examples
-            python3 test_examples.py
+            pytest --cov -k examples/
 
 
 workflows:

--- a/examples/README.md
+++ b/examples/README.md
@@ -367,7 +367,7 @@ docker run --rm -it -p 5901:5901 vnc_image xterm
 In a VNC client, connect to 127.0.0.1:5901, and enter the password used when configuring the container. `xterm` is a graphical terminal. It is used only as an example. Any GUI program can be used (e.g., Firefox).
 
 
-## JSON
+# JSON
 
 Neurodocker can generate Dockerfiles and Singularity files from JSON. For example, the file `example_specs.json` (contents below) can be used to with `neurodocker generate` as follows:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ Table of contents
   * [PETPVC](#petpvc)
   * [SPM12](#spm12)
   * [VNC](#vnc)
+- [JSON](#json)
 
 
 # Docker and Singularity options
@@ -364,3 +365,42 @@ docker run --rm -it -p 5901:5901 vnc_image xterm
 ```
 
 In a VNC client, connect to 127.0.0.1:5901, and enter the password used when configuring the container. `xterm` is a graphical terminal. It is used only as an example. Any GUI program can be used (e.g., Firefox).
+
+
+## JSON
+
+Neurodocker can generate Dockerfiles and Singularity files from JSON. For example, the file `example_specs.json` (contents below) can be used to with `neurodocker generate` as follows:
+
+```json
+{
+	"pkg_manager": "apt",
+	"instructions": [
+		["base", "debian"],
+		["ants", {
+			"version": "2.2.0"
+		}],
+		["install", ["git"]],
+		["miniconda", {
+			"create_env": "neuro",
+			"conda_install": ["numpy", "traits"],
+			"pip_install": ["nipype"]
+		}]
+	]
+}
+```
+
+```shell
+neurodocker generate [docker|singularity] example_spec.json
+```
+
+The JSON representation of a particular `neurodocker generate` command can be printed by adding the `--json` flag. The JSON representation above was found using the code snippet below.
+
+```shell
+neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \
+  --ants version=2.2.0 \
+  --install git \
+  --miniconda create_env=neuro \
+              conda_install='numpy traits' \
+              pip_install='nipype' \
+  --json
+```

--- a/examples/example_spec.json
+++ b/examples/example_spec.json
@@ -1,0 +1,15 @@
+{
+	"pkg_manager": "apt",
+	"instructions": [
+		["base", "debian"],
+		["ants", {
+			"version": "2.2.0"
+		}],
+		["install", ["git"]],
+		["miniconda", {
+			"create_env": "neuro",
+			"conda_install": ["numpy", "traits"],
+			"pip_install": ["nipype"]
+		}]
+	]
+}

--- a/examples/test_examples.py
+++ b/examples/test_examples.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Run the neurodocker examples and check for failures."""
 
 import glob
@@ -29,17 +28,26 @@ def test_examples_readme():
 
     print("Testing {} commands from the examples README".format(len(cmds)))
 
-    for c in cmds:
-        subprocess.run(c, shell=True, check=True)
+    with TemporaryChDir(here):
+        for c in cmds:
+            subprocess.run(c, shell=True, check=True)
 
 
 def test_specialized_examples():
     files = glob.glob(os.path.join(here, "**", "generate.sh"))
     print("Testing {} commands from specialized examples".format(len(files)))
-    for f in files:
-        subprocess.run(f, shell=True, check=True)
+    with TemporaryChDir(here):
+        for f in files:
+            subprocess.run(f, shell=True, check=True)
 
 
-if __name__ == '__main__':
-    test_examples_readme()
-    test_specialized_examples()
+class TemporaryChDir:
+    def __init__(self, wd):
+        self.wd = wd
+        self._wd_orig = os.getcwd()
+
+    def __enter__(self):
+        os.chdir(self.wd)
+
+    def __exit__(self, exc_type, exc_value, tb):
+        os.chdir(self._wd_orig)

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -8,7 +8,10 @@ $ neurodocker generate docker --help
 $ neurodocker generate singularity --help
 """
 
-from argparse import Action, ArgumentParser, RawDescriptionHelpFormatter
+from argparse import Action
+from argparse import ArgumentParser
+from argparse import RawDescriptionHelpFormatter
+import json
 import logging
 import sys
 
@@ -78,8 +81,10 @@ def _add_generate_common_arguments(parser):
 
     # To generate from file.
     p.add_argument(
-        '-f', '--file', dest='file',
+        'file', nargs='?',
         help="Generate file from JSON. Overrides other `generate` arguments")
+    p.add_argument(
+        '--json', action="store_true", help="Print Neurodocker JSON spec")
 
     # Other arguments (no order).
     p.add_argument(
@@ -288,7 +293,9 @@ def generate(namespace):
     }
 
     recipe_obj = recipe_objs[namespace.subsubparser_name](specs)
-    if not namespace.no_print:
+    if namespace.json:
+        print(json.dumps(specs))
+    elif not namespace.no_print:
         print(recipe_obj.render())
     if namespace.output:
         recipe_obj.save(filepath=namespace.output)


### PR DESCRIPTION
Fixes #211 

This PR proposes adding the `--json` flag to output the JSON representation of a particular `neurodocker generate` command. With this PR, `neurodocker generate [docker|singularity]` would also accept the path to a JSON file for generation.

for example:

```
neurodocker generate docker foobar.json
```