### PR TITLE
ENH: use ruaml-yaml to retain order of key elements from the templates etc

### DIFF
--- a/neurodocker/utils.py
+++ b/neurodocker/utils.py
@@ -4,11 +4,20 @@ import json
 import logging
 import re
 
-import yaml
 try:
-    from yaml import CLoader as Loader
+    # ruamel.yaml preserves map key order which helps to assure
+    # consistent use of templates etc in specification of the env variables
+    import ruamel.yaml as yaml
+    try:
+        from ruamel.yaml import CLoader as Loader
+    except ImportError:
+        from ruamel.yaml import Loader
 except ImportError:
-    from yaml import Loader
+    import yaml as yaml
+    try:
+        from yaml import CLoader as Loader
+    except ImportError:
+        from yaml import Loader
 
 
 def _count_key_occurence_list_of_tuples(list_of_tuples, key):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jinja2>=2.0
-PyYAML>=3.0
+#PyYAML>=3.0
+ruamel.yaml


### PR DESCRIPTION
Actually it is largely just a blind shot - feel welcome to close without merging.

The rationale was, if I use local current master of neurodocker (instead of a docker image) I am getting spurious changes such as 

```
 %environment
 export LANG="en_US.UTF-8"
-export LC_ALL="en_US.UTF-8"
 export ND_ENTRYPOINT="/neurodocker/startup.sh"
+export LC_ALL="en_US.UTF-8"
 export PATH="/opt/dcm2niix-v1.0.20180622/bin:$PATH"
 ```
suggesting that order of those entries is not guaranteed, so I thought it happened at the point of loading yaml, and tried to use ruaml-yaml which should retain the order, but I think it alone didn't help ;)
```
 %environment
-export LANG="en_US.UTF-8"
-export LC_ALL="en_US.UTF-8"
 export ND_ENTRYPOINT="/neurodocker/startup.sh"
+export LC_ALL="en_US.UTF-8"
+export LANG="en_US.UTF-8"
 export PATH="/opt/dcm2niix-v1.0.20180622/bin:$PATH"
```
so more needed ;-)

wanted to retain original order in templates instead of sorting since may be for some items order would be of importance