### PR TITLE
fix: install libxp6 and libxmu6 for 2010a

### DIFF
--- a/neurodocker/templates/matlabmcr.yaml
+++ b/neurodocker/templates/matlabmcr.yaml
@@ -22,8 +22,10 @@ generic:
       2012a: https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2012a/MCR_R2012a_glnxa64_installer.zip
       2010a: https://dl.dropbox.com/s/zz6me0c3v4yq5fd/MCR_R2010a_glnxa64_installer.bin
     dependencies:
-      apt: bc libncurses5 libxext6 libxpm-dev libxt6
+      apt: bc libncurses5 libxext6 libxmu6 libxpm-dev libxt6
       yum: bc libXext.x86_64 libXmu libXpm libXt.x86_64
+      debs:
+        - http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
     env:
       LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/runtime/glnxa64:{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/bin/glnxa64:{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/sys/os/glnxa64:{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/extern/bin/glnxa64"
       MATLABCMD: "{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/toolbox/matlab"
@@ -31,6 +33,7 @@ generic:
       {{ matlabmcr.install_dependencies() }}
       echo "Downloading MATLAB Compiler Runtime ..."
       {% if matlabmcr.version == "2010a" -%}
+      {{ matlabmcr.install_debs() }}
       curl {{ matlabmcr.curl_opts }} -o /tmp/MCRInstaller.bin {{ matlabmcr.binaries_url }}
       chmod +x /tmp/MCRInstaller.bin
       /tmp/MCRInstaller.bin -silent -P installLocation="{{ matlabmcr.install_path }}"


### PR DESCRIPTION
fixes issue addressed in https://github.com/kaczmarj/neurodocker/issues/228#issuecomment-427021970.