### PR TITLE
ENH: allow use of base miniconda environment

### DIFF
--- a/neurodocker/interfaces/interfaces.py
+++ b/neurodocker/interfaces/interfaces.py
@@ -186,7 +186,7 @@ class Miniconda(_BaseInterface):
     _pretty_name = 'Miniconda'
 
     _installed = False
-    _environments = set()
+    _environments = {'base'}
     _env_set = False
 
     def __init__(self, *args, create_env=None, use_env=None,
@@ -223,7 +223,7 @@ class Miniconda(_BaseInterface):
                 "cannot conda or pip install when creating environment from"
                 " yaml file")
 
-        if self.use_env is not None and not Miniconda._installed:
+        if self.use_env is not None and self.use_env != "base" and not Miniconda._installed:
             self._environments.add(self.use_env)
             Miniconda._installed = True
             Miniconda._env_set = True


### PR DESCRIPTION
Passing `use_env=base` to the miniconda call will use the base environment (i.e., will not create a new environment). This means that users will not have to call `source activate ENV`.