### PR TITLE
ADD: neurodebian freeze interface

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -2,43 +2,41 @@
 
 All of the examples below use `debian:stretch` as the base image, but any Docker image can be used as a base. Common base images (and their packages managers) are `ubuntu:16.04` (`apt`), `centos:7` (`yum`), `neurodebian:nd16.04` (`apt`), and `neurodebian:stretch` (`apt`).
 
-
-Table of contents
------------------
+## Table of contents
 
 - [Docker and Singularity options](#docker-and-singularity-options)
-  * [`--add-to-entrypoint`](#--add-to-entrypoint)
-  * [`--copy`](#--copy)
-  * [`--install`](#--install)
-  * [`--entrypoint`](#--entrypoint)
-  * [`-e / --env`](#-e----env)
-  * [`-r / --run`](#-r----run)
-  * [`--run-bash`](#--run-bash)
-  * [`-u / --user`](#-u----user)
-  * [`-w / --workdir`](#-w----workdir)
+  - [`--add-to-entrypoint`](#--add-to-entrypoint)
+  - [`--copy`](#--copy)
+  - [`--install`](#--install)
+  - [`--entrypoint`](#--entrypoint)
+  - [`-e / --env`](#-e----env)
+  - [`-r / --run`](#-r----run)
+  - [`--run-bash`](#--run-bash)
+  - [`-u / --user`](#-u----user)
+  - [`-w / --workdir`](#-w----workdir)
 - [Docker-only options](#docker-only-options)
-  * [`--arg`](#--arg)
-  * [`--cmd`](#--cmd)
-  * [`--expose`](#--expose)
-  * [`--label`](#--label)
-  * [`--volume`](#--volume)
+  - [`--arg`](#--arg)
+  - [`--cmd`](#--cmd)
+  - [`--expose`](#--expose)
+  - [`--label`](#--label)
+  - [`--volume`](#--volume)
 - [Neuroimaging software examples](#neuroimaging-software-examples)
-  * [AFNI](#afni)
-  * [ANTs](#ants)
-  * [Convert3D](#convert3d)
-  * [dcm2niix](#dcm2niix)
-  * [FreeSurfer](#freesurfer)
-  * [FSL](#fsl)
-  * [Matlab Compiler Runtime (MCR)](#matlab-compiler-runtime-mcr)
-  * [MINC](#minc)
-  * [Miniconda](#miniconda)
-  * [MRtrix3](#mrtrix3)
-  * [NeuroDebian](#neurodebian)
-  * [PETPVC](#petpvc)
-  * [SPM12](#spm12)
-  * [VNC](#vnc)
+  - [AFNI](#afni)
+  - [ANTs](#ants)
+  - [Convert3D](#convert3d)
+  - [dcm2niix](#dcm2niix)
+  - [FreeSurfer](#freesurfer)
+  - [FSL](#fsl)
+  - [Matlab Compiler Runtime (MCR)](#matlab-compiler-runtime-mcr)
+  - [MINC](#minc)
+  - [Miniconda](#miniconda)
+  - [MRtrix3](#mrtrix3)
+  - [NeuroDebian](#neurodebian)
+  - [PETPVC](#petpvc)
+  - [SPM12](#spm12)
+  - [VNC](#vnc)
 - [JSON](#json)
-
+- [NeuroDebian Freeze](#neurodebian-freeze)
 
 # Docker and Singularity options
 
@@ -81,14 +79,12 @@ neurodocker generate [docker|singularity] --base=centos:7 --pkg-manager=yum \
   --install yum_opts='--debug' git vim
 ```
 
-
 By default --install apt_opts uses --no-install-recommends to minimize container sizes. In few cases this can lead to unexpected behaviours and one can try to build a container without this option.
 
 ```shell
 neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \
   --install apt_opts='--quiet' git vim
-  ```
-
+```
 
 ## `--entrypoint`
 
@@ -214,8 +210,6 @@ This option adds a Docker `VOLUME` layer and does not apply to Singularity.
 neurodocker generate docker --base=debian:stretch --pkg-manager=apt \
   --volume /data
 ```
-
-
 
 # Neuroimaging software examples
 
@@ -349,7 +343,6 @@ neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=ap
   --spm12 version=r7219 method=binaries
 ```
 
-
 ## VNC
 
 ```shell
@@ -366,26 +359,31 @@ docker run --rm -it -p 5901:5901 vnc_image xterm
 
 In a VNC client, connect to 127.0.0.1:5901, and enter the password used when configuring the container. `xterm` is a graphical terminal. It is used only as an example. Any GUI program can be used (e.g., Firefox).
 
-
 # JSON
 
 Neurodocker can generate Dockerfiles and Singularity files from JSON. For example, the file `example_specs.json` (contents below) can be used to with `neurodocker generate` as follows:
 
 ```json
 {
-	"pkg_manager": "apt",
-	"instructions": [
-		["base", "debian"],
-		["ants", {
-			"version": "2.2.0"
-		}],
-		["install", ["git"]],
-		["miniconda", {
-			"create_env": "neuro",
-			"conda_install": ["numpy", "traits"],
-			"pip_install": ["nipype"]
-		}]
-	]
+  "pkg_manager": "apt",
+  "instructions": [
+    ["base", "debian"],
+    [
+      "ants",
+      {
+        "version": "2.2.0"
+      }
+    ],
+    ["install", ["git"]],
+    [
+      "miniconda",
+      {
+        "create_env": "neuro",
+        "conda_install": ["numpy", "traits"],
+        "pip_install": ["nipype"]
+      }
+    ]
+  ]
 }
 ```
 
@@ -404,3 +402,14 @@ neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=ap
               pip_install='nipype' \
   --json
 ```
+
+# NeuroDebian Freeze
+
+Use this with NeuroDebian distributions to pin the `apt` sources to a specific date (and optionally time). This can greatly help to produce a reproducible container specification, because all calls to `apt-get update` will point to the same snapshots of packages. Please see the script [`nd_freeze`](http://neuro.debian.net/pkgs/neurodebian-freeze.html) for more information. THe usage is as follows:
+
+```shell
+neurodocker generate [docker|singularity] --base=neurodebian:stretch --pkg-manager=apt \
+  --ndfreeze date=20180312
+```
+
+The call to `nd_freeze` will occur close to the beginning of the Docker or Singularity specification, regardless of the position of `--ndfreeze` on the command line.

--- a/neurodocker/generators/common.py
+++ b/neurodocker/generators/common.py
@@ -10,7 +10,8 @@ from neurodocker.interfaces._base import apt_install
 from neurodocker.interfaces._base import yum_install
 
 _installation_implementations = {
-    ii._name: ii for ii in _BaseInterface.__subclasses__()
+    ii._name: ii
+    for ii in _BaseInterface.__subclasses__()
 }
 
 ND_DIRECTORY = posixpath.join(posixpath.sep, 'neurodocker')
@@ -47,8 +48,7 @@ def _install(pkgs, pkg_manager):
     }
     if pkg_manager not in installers.keys():
         raise ValueError(
-            "package manager '{}' not recognized".format(pkg_manager)
-        )
+            "package manager '{}' not recognized".format(pkg_manager))
     opts_key = "{}_opts=".format(pkg_manager)
     opts = [jj for jj in pkgs if jj.startswith(opts_key)]
     pkgs = [kk for kk in pkgs if kk not in opts]
@@ -69,9 +69,8 @@ class _Users:
         if user not in cls.initialized_users:
             cls.initialized_users.add(user)
             return (
-                "useradd --no-user-group --create-home --shell /bin/bash {0}"
-                .format(user)
-            )
+                "useradd --no-user-group --create-home --shell /bin/bash {0}".
+                format(user))
         else:
             return False
 

--- a/neurodocker/generators/singularity.py
+++ b/neurodocker/generators/singularity.py
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 
 
 class _SingularityRecipeImplementations:
-
     def __init__(self, singularity_recipe_object):
         self._singobj = singularity_recipe_object
 
@@ -72,7 +71,6 @@ class _SingularityRecipeImplementations:
 
 
 class SingularityRecipe(ContainerSpecGenerator):
-
     def __init__(self, specs):
         self._specs = copy.deepcopy(specs)
 
@@ -88,21 +86,19 @@ class SingularityRecipe(ContainerSpecGenerator):
 
         self._implementations = {
             **_installation_implementations,
-            **dict(inspect.getmembers(_SingularityRecipeImplementations(self),
-                                      predicate=inspect.ismethod))
+            **dict(
+                inspect.getmembers(
+                    _SingularityRecipeImplementations(self),
+                    predicate=inspect.ismethod))
         }
 
-        self._order = (
-            ('header', self._header),
-            ('help', self._help),
-            ('setup', self._setup),
-            ('post', self._post),
-            ('environment', self._environment),
-            ('files', self._files),
-            ('runscript', self._runscript),
-            ('test', self._test),
-            ('labels', self._labels)
-        )
+        self._order = (('header', self._header), ('help', self._help),
+                       ('setup', self._setup), ('post', self._post),
+                       ('environment', self._environment), ('files',
+                                                            self._files),
+                       ('runscript',
+                        self._runscript), ('test', self._test), ('labels',
+                                                                 self._labels))
         self._parts_filled = False
         _Users.clear_memory()
         self._add_neurodocker_header()
@@ -132,15 +128,12 @@ class SingularityRecipe(ContainerSpecGenerator):
         return "%post\n" + "\n\n".join(self._post)
 
     def _render_environment(self):
-        return (
-            "%environment\n"
-            + "\n".join('export {}="{}"'.format(*kv)
-                        for kv in self._environment))
+        return ("%environment\n" + "\n".join('export {}="{}"'.format(*kv)
+                                             for kv in self._environment))
 
     def _render_files(self):
-        return (
-            "%files\n"
-            + "\n".join("{} {}".format(*f) for f in self._files))
+        return ("%files\n" + "\n".join("{} {}".format(*f)
+                                       for f in self._files))
 
     def _render_runscript(self):
         return "%runscript\n" + self._runscript
@@ -152,10 +145,10 @@ class SingularityRecipe(ContainerSpecGenerator):
         return "%labels\n" + "\n".join(self._labels)
 
     def _add_neurodocker_header(self):
-        kwds = {
-            'version': 'generic',
-            'method': 'custom'}
-        self._specs['instructions'].insert(1, ('_header', kwds))
+        kwds = {'version': 'generic', 'method': 'custom'}
+        # If ndfreeze is requested, put it before the neurodocker header.
+        offset = 1 if self._specs['instructions'][1][0] == 'ndfreeze' else 0
+        self._specs['instructions'].insert(1 + offset, ('_header', kwds))
 
     def _fill_parts(self):
         pkg_man = self._specs['pkg_manager']
@@ -167,8 +160,8 @@ class SingularityRecipe(ContainerSpecGenerator):
                     try:
                         interface = impl(pkg_manager=pkg_man, **params)
                     except Exception as exc:
-                        logger.error(
-                            "Failed to instantiate {}: {}".format(impl, exc))
+                        logger.error("Failed to instantiate {}: {}".format(
+                            impl, exc))
                         raise
                     if interface.env:
                         _this_env = interface.render_env()

--- a/neurodocker/interfaces/interfaces.py
+++ b/neurodocker/interfaces/interfaces.py
@@ -20,8 +20,13 @@ class AFNI(_BaseInterface):
     _name = 'afni'
     _pretty_name = 'AFNI'
 
-    def __init__(self, *args, install_python2=False, install_python3=False,
-                 install_r=False, install_r_pkgs=False, **kwargs):
+    def __init__(self,
+                 *args,
+                 install_python2=False,
+                 install_python3=False,
+                 install_r=False,
+                 install_r_pkgs=False,
+                 **kwargs):
         self.install_python2 = install_python2
         self.install_python3 = install_python3
         self.install_r = install_r
@@ -164,9 +169,8 @@ class MatlabMCR(_BaseInterface):
             return "v{}".format(self._mcr_versions[self.version])
         except KeyError:
             raise ValueError(
-                "Matlab MCR version not known for Matlab version '{}'."
-                .format(self.version)
-            )
+                "Matlab MCR version not known for Matlab version '{}'.".format(
+                    self.version))
 
 
 class MINC(_BaseInterface):
@@ -189,8 +193,13 @@ class Miniconda(_BaseInterface):
     _environments = {'base'}
     _env_set = False
 
-    def __init__(self, *args, create_env=None, use_env=None,
-                 conda_install=None, pip_install=None, yaml_file=None,
+    def __init__(self,
+                 *args,
+                 create_env=None,
+                 use_env=None,
+                 conda_install=None,
+                 pip_install=None,
+                 yaml_file=None,
                  **kwargs):
         self.create_env = create_env
         self.use_env = use_env
@@ -250,6 +259,20 @@ class MRtrix3(_BaseInterface):
         super().__init__(self._name, *args, **kwargs)
 
 
+class NDFreeze(_BaseInterface):
+    """Create instance of NDFreeze oject."""
+
+    _name = "ndfreeze"
+
+    def __init__(self, date, *args, **kwargs):
+        self.date = date
+        super().__init__(
+            self._name, version='latest', method='custom', *args, **kwargs)
+        if self.pkg_manager != 'apt':
+            raise ValueError(
+                "nd_freeze cannot be used with a non-apt package manager")
+
+
 class NeuroDebian(_BaseInterface):
     """Create instance of NeuroDebian object."""
 
@@ -276,9 +299,8 @@ class NeuroDebian(_BaseInterface):
 
         self._server = NeuroDebian._servers.get(server, None)
         if self._server is None:
-            msg = (
-                "Server '{}' not found. Choices are "
-                + ', '.join(NeuroDebian._servers.keys()))
+            msg = ("Server '{}' not found. Choices are " + ', '.join(
+                NeuroDebian._servers.keys()))
             raise ValueError(msg.format(server))
 
         self._full = 'full' if full else 'libre'
@@ -287,8 +309,12 @@ class NeuroDebian(_BaseInterface):
             os=self.os_codename, srv=self._server, full=self._full)
 
         super().__init__(
-            self._name, version='generic', method='custom',
-            os_codename=os_codename, server=server, **kwargs)
+            self._name,
+            version='generic',
+            method='custom',
+            os_codename=os_codename,
+            server=server,
+            **kwargs)
 
 
 class PETPVC(_BaseInterface):
@@ -312,12 +338,12 @@ class SPM12(_BaseInterface):
 
         matlabmcr_version = self.binaries_url[-9:-4]
         self.matlabmcr_obj = MatlabMCR(matlabmcr_version, self.pkg_manager)
-        self.mcr_path = posixpath.join(
-            self.matlabmcr_obj.install_path, self.matlabmcr_obj.mcr_version)
+        self.mcr_path = posixpath.join(self.matlabmcr_obj.install_path,
+                                       self.matlabmcr_obj.mcr_version)
 
     def render_run(self):
-        return "\n".join(
-            (self.matlabmcr_obj.render_run(), super().render_run()))
+        return "\n".join((self.matlabmcr_obj.render_run(),
+                          super().render_run()))
 
     def render_env(self):
         """Return dictionary with rendered keys and values."""

--- a/neurodocker/neurodocker.py
+++ b/neurodocker/neurodocker.py
@@ -27,6 +27,7 @@ logger = logging.getLogger(__name__)
 # https://stackoverflow.com/a/9028031/5666087
 class OrderedArgs(Action):
     """Object to preserve order in which command-line arguments are given."""
+
     def __call__(self, parser, namespace, values, option_string=None):
         if 'ordered_args' not in namespace:
             setattr(namespace, 'ordered_args', [])
@@ -48,102 +49,140 @@ def _add_generate_common_arguments(parser):
     p.add_argument(
         "-b", "--base", help="Base Docker image. E.g., debian:stretch")
     p.add_argument(
-        "-p", "--pkg-manager", choices={'apt', 'yum'},
+        "-p",
+        "--pkg-manager",
+        choices={'apt', 'yum'},
         help="Linux package manager.")
     p.add_argument(
-        '--add-to-entrypoint', action=OrderedArgs,
+        '--add-to-entrypoint',
+        action=OrderedArgs,
         help=("Add a command to the file /neurodocker/startup.sh, which is the"
               " container's default entrypoint."))
     p.add_argument(
-        '--copy', action=OrderedArgs, nargs="+",
+        '--copy',
+        action=OrderedArgs,
+        nargs="+",
         help="Copy files into container. Use format <src>... <dest>")
     p.add_argument(
-        '--install', action=OrderedArgs, nargs="+",
+        '--install',
+        action=OrderedArgs,
+        nargs="+",
         help=("Install system packages with apt-get or yum, depending on the"
               " package manager specified."))
     p.add_argument(
-        '--entrypoint', action=OrderedArgs,
+        '--entrypoint',
+        action=OrderedArgs,
         help="Set the container's entrypoint (Docker) / append to runscript"
-             " (Singularity)")
+        " (Singularity)")
     p.add_argument(
-        '-e', '--env', action=OrderedArgs, nargs="+", type=_list_of_kv,
+        '-e',
+        '--env',
+        action=OrderedArgs,
+        nargs="+",
+        type=_list_of_kv,
         help="Set environment variable(s). Use the format KEY=VALUE")
     p.add_argument(
-        '-r', '--run', action=OrderedArgs,
+        '-r',
+        '--run',
+        action=OrderedArgs,
         help="Run a command when building container")
     p.add_argument(
         '--run-bash', action=OrderedArgs, help="Run a command in bash")
     p.add_argument(
-        '-u', '--user', action=OrderedArgs,
+        '-u',
+        '--user',
+        action=OrderedArgs,
         help="Switch current user (creates user if necessary)")
     p.add_argument(
         '-w', '--workdir', action=OrderedArgs, help="Set working directory")
 
     # To generate from file.
     p.add_argument(
-        'file', nargs='?',
+        'file',
+        nargs='?',
         help="Generate file from JSON. Overrides other `generate` arguments")
     p.add_argument(
         '--json', action="store_true", help="Print Neurodocker JSON spec")
 
     # Other arguments (no order).
     p.add_argument(
-        '-o', '--output', dest="output",
+        '-o',
+        '--output',
+        dest="output",
         help="If specified, save Dockerfile to file with this name.")
     p.add_argument(
-        '--no-print', dest='no_print', action="store_true",
+        '--no-print',
+        dest='no_print',
+        action="store_true",
         help="Do not print the generated file")
 
     _ndeb_servers = ", ".join(
-        _installation_implementations['neurodebian']._servers.keys()
-    )
+        _installation_implementations['neurodebian']._servers.keys())
 
     # Software package options.
     pkgs_help = {
-        "all": "Install software packages. Each argument takes a list of"
-               " key=value pairs. Where applicable, the default installation"
-               " behavior is to install by downloading and uncompressing"
-               " binaries. Some programs can be built from source.",
-        "afni": "Install AFNI. Valid keys are version (required), method,"
-                " install_path, install_r, install_r_pkgs, install_python2,"
-                " and install_python3. Only the latest version and version"
-                " 17.2.02 are supported at this time.",
-        "ants": "Install ANTs. Valid keys are version (required), method"
-                " install_path, cmake_opts, and make_opts. Version can be a "
-                " git commit hash if building from source.",
-        "convert3d": "Install Convert3D. Valid keys are version (required),"
-                     " method, and install_path.",
-        "dcm2niix": "Install dcm2niix. Valid keys are version, method,"
-                    " install_path, cmake_opts, and make_opts",
-        "freesurfer": "Install FreeSurfer. Valid keys are version (required),"
-                      " method, install_path, and exclude_paths. A FreeSurfer"
-                      " license is required to run the software and is not"
-                      " provided by Neurodocker.",
-        "fsl": "Install FSL. Valid keys are version (required), method,"
-               " install_path, and exclude_paths.",
-        "matlabmcr": "Install Matlab Compiler Runtime. Valid keys are version,"
-                     " method, and install_path",
-        "miniconda": "Install Miniconda. Valid keys are install_path,"
-                     " env_name, conda_install, pip_install, conda_opts,"
-                     " pip_opts, activate (default false), and version"
-                     " (defaults to latest). The options conda_install and"
-                     " pip_install accept strings of packages: conda_install="
-                     '"python=3.6 numpy traits".',
-        "mrtrix3": "Install MRtrix3. Valid keys are version (required),"
-                   " method, and install_path",
-        "neurodebian": "Add NeuroDebian repository. Valid keys are "
-                       "os_codename (e.g., zesty), server (e.g., usa-nh), and"
-                       " full (if true, use non-free packages). Valid download"
-                       " servers are {}.".format(_ndeb_servers),
-        "spm12": "Install SPM12 and its dependency, Matlab Compiler Runtime."
-                 " Valid keys are version and install_path.",
-        "minc": "Install MINC. Valid keys is version (required), method, and"
-                " install_path. Only version 1.9.15 is supported at this"
-                " time.",
-        "petpvc": "Install PETPVC. Valid keys are version (required), method,"
-                  " and install_path.",
-        "vnc": "Install a VNC server. Valid keys are passwd (required),"
-               " start_at_runtime, and geometry."
+        "all":
+        "Install software packages. Each argument takes a list of"
+        " key=value pairs. Where applicable, the default installation"
+        " behavior is to install by downloading and uncompressing"
+        " binaries. Some programs can be built from source.",
+        "afni":
+        "Install AFNI. Valid keys are version (required), method,"
+        " install_path, install_r, install_r_pkgs, install_python2,"
+        " and install_python3. Only the latest version and version"
+        " 17.2.02 are supported at this time.",
+        "ants":
+        "Install ANTs. Valid keys are version (required), method"
+        " install_path, cmake_opts, and make_opts. Version can be a "
+        " git commit hash if building from source.",
+        "convert3d":
+        "Install Convert3D. Valid keys are version (required),"
+        " method, and install_path.",
+        "dcm2niix":
+        "Install dcm2niix. Valid keys are version, method,"
+        " install_path, cmake_opts, and make_opts",
+        "freesurfer":
+        "Install FreeSurfer. Valid keys are version (required),"
+        " method, install_path, and exclude_paths. A FreeSurfer"
+        " license is required to run the software and is not"
+        " provided by Neurodocker.",
+        "fsl":
+        "Install FSL. Valid keys are version (required), method,"
+        " install_path, and exclude_paths.",
+        "matlabmcr":
+        "Install Matlab Compiler Runtime. Valid keys are version,"
+        " method, and install_path",
+        "miniconda":
+        "Install Miniconda. Valid keys are install_path,"
+        " env_name, conda_install, pip_install, conda_opts,"
+        " pip_opts, activate (default false), and version"
+        " (defaults to latest). The options conda_install and"
+        " pip_install accept strings of packages: conda_install="
+        '"python=3.6 numpy traits".',
+        "mrtrix3":
+        "Install MRtrix3. Valid keys are version (required),"
+        " method, and install_path",
+        "ndfreeze":
+        "Use the NeuroDebian command `nd_freeze` to freeze the apt"
+        " sources to a certain date.",
+        "neurodebian":
+        "Add NeuroDebian repository. Valid keys are "
+        "os_codename (e.g., zesty), server (e.g., usa-nh), and"
+        " full (if true, use non-free packages). Valid download"
+        " servers are {}.".format(_ndeb_servers),
+        "spm12":
+        "Install SPM12 and its dependency, Matlab Compiler Runtime."
+        " Valid keys are version and install_path.",
+        "minc":
+        "Install MINC. Valid keys is version (required), method, and"
+        " install_path. Only version 1.9.15 is supported at this"
+        " time.",
+        "petpvc":
+        "Install PETPVC. Valid keys are version (required), method,"
+        " and install_path.",
+        "vnc":
+        "Install a VNC server. Valid keys are passwd (required),"
+        " start_at_runtime, and geometry."
     }
 
     pkgs = p.add_argument_group(
@@ -156,8 +195,13 @@ def _add_generate_common_arguments(parser):
         # MRtrix3 does not need any arguments by default.
         nargs = "*" if pkg == "mrtrix3" else "+"
         pkgs.add_argument(
-            flag, dest=pkg, nargs=nargs, action=OrderedArgs, metavar="",
-            type=_list_of_kv, help=pkgs_help[pkg])
+            flag,
+            dest=pkg,
+            nargs=nargs,
+            action=OrderedArgs,
+            metavar="",
+            type=_list_of_kv,
+            help=pkgs_help[pkg])
 
 
 def _add_generate_docker_arguments(parser):
@@ -166,22 +210,36 @@ def _add_generate_docker_arguments(parser):
 
     # Arguments that should be ordered.
     p.add_argument(
-        '--add', action=OrderedArgs, nargs="+",
+        '--add',
+        action=OrderedArgs,
+        nargs="+",
         help="Dockerfile ADD instruction. Use format <src>... <dest>")
     p.add_argument(
-        '--arg', action=OrderedArgs, nargs="+", type=_list_of_kv,
+        '--arg',
+        action=OrderedArgs,
+        nargs="+",
+        type=_list_of_kv,
         help="Dockerfile ARG instruction. Use format KEY[=DEFAULT_VALUE] ...")
     p.add_argument(
-        '--cmd', action=OrderedArgs, nargs="+",
+        '--cmd',
+        action=OrderedArgs,
+        nargs="+",
         help="Dockerfile CMD instruction.")
     p.add_argument(
-        '--expose', nargs="+", action=OrderedArgs,
+        '--expose',
+        nargs="+",
+        action=OrderedArgs,
         help="Dockerfile EXPOSE instruction.")
     p.add_argument(
-        '--label', action=OrderedArgs, nargs="+", type=_list_of_kv,
+        '--label',
+        action=OrderedArgs,
+        nargs="+",
+        type=_list_of_kv,
         help="Dockerfile LABEL instruction.")
     p.add_argument(
-        '--volume', action=OrderedArgs, nargs="+",
+        '--volume',
+        action=OrderedArgs,
+        nargs="+",
         help="Dockerfile VOLUME instruction.")
 
 
@@ -193,12 +251,16 @@ def _add_generate_singularity_arguments(parser):
 def _add_reprozip_trace_arguments(parser):
     """Add arguments to `parser` for sub-command `reprozip-trace`."""
     p = parser
-    p.add_argument('container',
-                   help="Running container in which to trace commands.")
+    p.add_argument(
+        'container', help="Running container in which to trace commands.")
     p.add_argument('commands', nargs='+', help="Command(s) to trace.")
-    p.add_argument('--dir', '-d', dest="packfile_save_dir", default=".",
-                   help=("Directory in which to save pack file. Default "
-                         "is current directory."))
+    p.add_argument(
+        '--dir',
+        '-d',
+        dest="packfile_save_dir",
+        default=".",
+        help=("Directory in which to save pack file. Default "
+              "is current directory."))
 
 
 def _add_reprozip_merge_arguments(parser):
@@ -216,18 +278,23 @@ def create_parser():
 
     verbosity_choices = ('debug', 'info', 'warning', 'error', 'critical')
     parser.add_argument("-v", "--verbosity", choices=verbosity_choices)
-    parser.add_argument("-V", "--version", action="version",
-                        version=('neurodocker version {}'.format(__version__)))
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=('neurodocker version {}'.format(__version__)))
 
     subparsers = parser.add_subparsers(
-        dest="subparser_name", title="subcommands",
+        dest="subparser_name",
+        title="subcommands",
         description="valid subcommands")
 
     # `neurodocker generate` parsers.
     generate_parser = subparsers.add_parser(
         'generate', help="generate recipes")
     generate_subparsers = generate_parser.add_subparsers(
-        dest="subsubparser_name", title="subcommands",
+        dest="subsubparser_name",
+        title="subcommands",
         description="valid subcommands")
     generate_docker_parser = generate_subparsers.add_parser(
         'docker', help="generate Dockerfile")
@@ -241,7 +308,8 @@ def create_parser():
     # `neurodocker reprozip` parsers.
     reprozip_parser = subparsers.add_parser('reprozip', help="")
     reprozip_subparsers = reprozip_parser.add_subparsers(
-        dest="subsubparser_name", title="subcommands",
+        dest="subsubparser_name",
+        title="subcommands",
         description="valid subcommands")
     reprozip_trace_parser = reprozip_subparsers.add_parser(
         'trace', help="minify container for traced command(s)")
@@ -318,8 +386,8 @@ def reprozip_merge(namespace):
 
 
 def _validate_generate_args(namespace):
-    if (namespace.file is None and
-       (namespace.base is None or namespace.pkg_manager is None)):
+    if (namespace.file is None
+            and (namespace.base is None or namespace.pkg_manager is None)):
         raise ValueError("-b/--base and -p/--pkg-manager are required if not"
                          " generating from JSON file.")
 

--- a/neurodocker/parser.py
+++ b/neurodocker/parser.py
@@ -34,7 +34,6 @@ class _SpecsParser:
     --------
     >>> specs = {
     ...     'pkg_manager': 'apt',
-    ...     'check_urls': False,
     ...     'instructions': [
     ...         ('base', 'ubuntu:17.04'),
     ...         ('ants', {'version': '2.2.0'}),
@@ -44,8 +43,10 @@ class _SpecsParser:
     ... }
     >>> SpecsParser(specs)
     """
-    VALID_TOP_LEVEL_KEYS = ['check_urls', 'instructions', 'pkg_manager',
-                            'generation_timestamp', 'neurodocker_version']
+    VALID_TOP_LEVEL_KEYS = [
+        'instructions', 'pkg_manager', 'generation_timestamp',
+        'neurodocker_version'
+    ]
 
     VALID_INSTRUCTIONS_KEYS = Dockerfile._implementations.keys()
 
@@ -79,14 +80,12 @@ class _SpecsParser:
             raise KeyError("The first item in specs['instructions'] must be "
                            "a tuple ('base', '<base_image>').")
 
-        _check_for_invalid_keys(self.specs.keys(),
-                                self.VALID_TOP_LEVEL_KEYS,
+        _check_for_invalid_keys(self.specs.keys(), self.VALID_TOP_LEVEL_KEYS,
                                 'top-level')
 
         instructions_keys = [k for k, _ in self.specs['instructions']]
         _check_for_invalid_keys(instructions_keys,
-                                self.VALID_INSTRUCTIONS_KEYS,
-                                'instructions')
+                                self.VALID_INSTRUCTIONS_KEYS, 'instructions')
 
     def _validate_software_options(self):
         """Raise ValueError if a key is present that does not belong in a

--- a/neurodocker/templates/ndfreeze.yaml
+++ b/neurodocker/templates/ndfreeze.yaml
@@ -1,0 +1,9 @@
+# Instructions to run `nd_freeze` in NeuroDebian images.
+
+generic:
+  custom:
+    dependencies:
+      apt: neurodebian-freeze
+    instructions: |
+      {{ ndfreeze.install_dependencies() }}
+      nd_freeze {{ ndfreeze.cmd_args | default('') }} {{ ndfreeze.date }}

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -9,29 +9,28 @@ from neurodocker.neurodocker import main
 
 
 def test_generate():
-    args = (
-        "generate docker -b ubuntu:17.04 -p apt"
-        " --arg FOO=BAR BAZ"
-        " --afni version=latest method=source"
-        " --ants version=2.2.0 method=source"
-        " --freesurfer version=6.0.0"
-        " --fsl version=5.0.10"
-        " --user=neuro"
-        " --miniconda create_env=neuro conda_install=python=3.6.2"
-        " --user=root"
-        " --mrtrix3 version=3.0_RC3"
-        " --neurodebian os_codename=zesty server=usa-nh"
-        " --spm12 version=r7219 matlab_version=R2017a"
-        " --expose 1234 9000"
-        " --volume /var /usr/bin"
-        " --label FOO=BAR BAZ=CAT"
-        " --copy relpath/to/file.txt /tmp/file.txt"
-        " --add relpath/to/file2.txt /tmp/file2.txt"
-        " --cmd '--arg1' '--arg2'"
-        " --workdir /home"
-        " --install git"
-        " --user=neuro"
-    )
+    args = ("generate docker -b ubuntu:17.04 -p apt"
+            " --arg FOO=BAR BAZ"
+            " --ndfreeze date=20180312"
+            " --afni version=latest method=source"
+            " --ants version=2.2.0 method=source"
+            " --freesurfer version=6.0.0"
+            " --fsl version=5.0.10"
+            " --user=neuro"
+            " --miniconda create_env=neuro conda_install=python=3.6.2"
+            " --user=root"
+            " --mrtrix3 version=3.0_RC3"
+            " --neurodebian os_codename=zesty server=usa-nh"
+            " --spm12 version=r7219 matlab_version=R2017a"
+            " --expose 1234 9000"
+            " --volume /var /usr/bin"
+            " --label FOO=BAR BAZ=CAT"
+            " --copy relpath/to/file.txt /tmp/file.txt"
+            " --add relpath/to/file2.txt /tmp/file2.txt"
+            " --cmd '--arg1' '--arg2'"
+            " --workdir /home"
+            " --install git"
+            " --user=neuro")
     main(args.split())
 
     with pytest.raises(SystemExit):
@@ -62,9 +61,8 @@ def test_generate_opts(capsys):
 
     main(args.format('--env KEY=VAL KEY2=VAL').split())
     out, _ = capsys.readouterr()
-    assert (
-        ('ENV KEY="VAL" \\' in out and 'KEY="VAL"' in out)
-        or ('ENV KEY2="VAL" \\' in out and 'KEY="VAL"'))
+    assert (('ENV KEY="VAL" \\' in out and 'KEY="VAL"' in out)
+            or ('ENV KEY2="VAL" \\' in out and 'KEY="VAL"'))
 
     main(args.format('--expose 1230 1231').split())
     out, _ = capsys.readouterr()
@@ -78,6 +76,11 @@ def test_generate_opts(capsys):
     out, _ = capsys.readouterr()
     assert "vi" in out
 
+    # Test that nd_freeze comes before the header.
+    main(args.format('--ndfreeze date=20180312').split())
+    out, _ = capsys.readouterr()
+    assert out.find("nd_freeze") < out.find("ND_ENTRYPOINT")
+
 
 @pytest.mark.xfail
 def test_generate_from_json(capsys, tmpdir):
@@ -87,11 +90,18 @@ def test_generate_from_json(capsys, tmpdir):
     main(cmd.split())
     true, _ = capsys.readouterr()
 
-    specs = {'generation_timestamp': '2017-08-31 21:49:04',
-             'instructions': [['base', 'debian:stretch'],
-                              ['convert3d', {'version': '1.0.0'}]],
-             'neurodocker_version': '0.2.0-18-g9227b17',
-             'pkg_manager': 'apt'}
+    specs = {
+        'generation_timestamp':
+        '2017-08-31 21:49:04',
+        'instructions': [['base', 'debian:stretch'],
+                         ['convert3d', {
+                             'version': '1.0.0'
+                         }]],
+        'neurodocker_version':
+        '0.2.0-18-g9227b17',
+        'pkg_manager':
+        'apt'
+    }
     str_specs = json.dumps(specs)
     filepath = tmpdir.join("specs.json")
     filepath.write(str_specs)


### PR DESCRIPTION
Closes #238 

This pull request proposes adding an interface for neurodebian freeze (`nd_freeze` on the command line). This will pin the `apt` sources in a neurodebian image to a certain date (and optionally time).

Usage:

```shell
neurodocker generate docker -b neurodebian:stretch -p apt --ndfreeze date=20180312
```

Note that the call to `nd_freeze` will happen as early as possible in the Docker or Singularity specification.