### PR TITLE
FIX: check if user exists before creating

### DIFF
--- a/neurodocker/generators/common.py
+++ b/neurodocker/generators/common.py
@@ -71,8 +71,8 @@ class _Users:
             return (
                 # Test whether the user exists. If not, add user.
                 'test "$(getent passwd {0})" ||'
-                ' useradd --no-user-group --create-home --shell /bin/bash {0}')
-                .format(user)
+                ' useradd --no-user-group --create-home --shell /bin/bash {0}'
+                .format(user))
         else:
             return False
 

--- a/neurodocker/generators/common.py
+++ b/neurodocker/generators/common.py
@@ -69,8 +69,10 @@ class _Users:
         if user not in cls.initialized_users:
             cls.initialized_users.add(user)
             return (
-                "useradd --no-user-group --create-home --shell /bin/bash {0}".
-                format(user))
+                # Test whether the user exists. If not, add user.
+                'test "$(getent passwd {0})" ||'
+                ' useradd --no-user-group --create-home --shell /bin/bash {0}')
+                .format(user)
         else:
             return False
 


### PR DESCRIPTION
Fixes #250 

Problem: if we base an image on an image that has the non-root user 'neuro', neurodocker will try to create the user `neuro`. however, this will fail. this PR fixes that.