### PR TITLE
add versions 6.0.0 and 6.0.1

### DIFF
--- a/neurodocker/templates/fsl.yaml
+++ b/neurodocker/templates/fsl.yaml
@@ -11,6 +11,8 @@
 generic:
   binaries:
     urls:
+      "6.0.1": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.1-centos6_64.tar.gz
+      "6.0.0": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-6.0.0-centos6_64.tar.gz
       "5.0.11": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-5.0.11-centos6_64.tar.gz
       "5.0.10": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-5.0.10-centos6_64.tar.gz
       "5.0.9": https://fsl.fmrib.ox.ac.uk/fsldownloads/fsl-5.0.9-centos6_64.tar.gz


### PR DESCRIPTION
closes #265 

this PR adds the urls to the tarballs for fsl 6.0.0 and fsl 6.0.1.