### PR TITLE
BF: set $USER to output of whoami if env var USER is not defined

### DIFF
--- a/neurodocker/templates/_header.yaml
+++ b/neurodocker/templates/_header.yaml
@@ -25,6 +25,7 @@ generic:
       if [ ! -f "$ND_ENTRYPOINT" ]; then
         echo '#!/usr/bin/env bash' >> "$ND_ENTRYPOINT"
         echo 'set -e' >> "$ND_ENTRYPOINT"
+        echo ': ${USER:=`whoami`}' >> "$ND_ENTRYPOINT"
         echo 'if [ -n "$1" ]; then "$@"; else /usr/bin/env bash; fi' >> "$ND_ENTRYPOINT";
       fi
       chmod -R 777 /neurodocker && chmod a+s /neurodocker

--- a/neurodocker/templates/_header.yaml
+++ b/neurodocker/templates/_header.yaml
@@ -25,7 +25,7 @@ generic:
       if [ ! -f "$ND_ENTRYPOINT" ]; then
         echo '#!/usr/bin/env bash' >> "$ND_ENTRYPOINT"
         echo 'set -e' >> "$ND_ENTRYPOINT"
-        echo ': ${USER:=`whoami`}' >> "$ND_ENTRYPOINT"
+        echo 'export USER="${USER:=`whoami`}"' >> "$ND_ENTRYPOINT"
         echo 'if [ -n "$1" ]; then "$@"; else /usr/bin/env bash; fi' >> "$ND_ENTRYPOINT";
       fi
       chmod -R 777 /neurodocker && chmod a+s /neurodocker


### PR DESCRIPTION
Current use case is a singularity image, which is ran with -e to avoid side
effects from env vars on the host box.  But USER variable is often used/relied
upon different tools. Immediate use case - FSL 6.0.1

    $ DISPLAY=:0 fsl
    Error in startup script: can't read "env(USER)": no such variable
        while executing
    "set USER       $env(USER)"
        (file "/opt/fsl-6.0.1/tcl/fslstart.tcl" line 6)
        invoked from within
    "source [ file dirname [ info script ] ]/fslstart.tcl"
        (file "/opt/fsl-6.0.1/tcl/fsl.tcl" line 71)
        invoked from within
    "source ${FSLDIR}/tcl/${origname}.tcl"
        (file "/opt/fsl-6.0.1/bin/fsl" line 22)

but I thought it would generally be useful and should not have
side-effects, that is why added to the generic startup script.
The only concern I just got is reprozip minimized images -- would they
have whoami?  But even then, the situation should not be grave since
`whoami` seems to be not executed if USER is defined, so should generally
work ;)