### PR TITLE
fix: do not rm /tmp/* or /var/tmp/*

### DIFF
--- a/neurodocker/interfaces/_base.py
+++ b/neurodocker/interfaces/_base.py
@@ -20,7 +20,7 @@ apt-get install -y {{ apt_opts|default('-q --no-install-recommends') }} \\\
     {%- endif -%}
 {% endfor %}
 apt-get clean
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+rm -rf /var/lib/apt/lists/*
 """
 apt_install = jinja2.Template(apt_install)
 
@@ -33,7 +33,7 @@ yum_install = """yum install -y {{ yum_opts|default('-q') }} \\\
     {%- endif -%}
 {% endfor %}
 yum clean packages
-rm -rf /var/cache/yum/* /tmp/* /var/tmp/*
+rm -rf /var/cache/yum/*
 """
 yum_install = jinja2.Template(yum_install)
 
@@ -44,7 +44,7 @@ rm /tmp/toinstall.deb
 {% endfor -%}
 apt-get install -f
 apt-get clean
-rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+rm -rf /var/lib/apt/lists/*
 """
 deb_install = jinja2.Template(deb_install)
 

--- a/neurodocker/templates/matlabmcr.yaml
+++ b/neurodocker/templates/matlabmcr.yaml
@@ -30,16 +30,18 @@ generic:
       LD_LIBRARY_PATH: "$LD_LIBRARY_PATH:/usr/lib/x86_64-linux-gnu:{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/runtime/glnxa64:{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/bin/glnxa64:{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/sys/os/glnxa64:{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/extern/bin/glnxa64"
       MATLABCMD: "{{ matlabmcr.install_path }}/{{ matlabmcr.mcr_version }}/toolbox/matlab"
     instructions: |
+      export TMPDIR="$(mktemp -d)"
       {{ matlabmcr.install_dependencies() }}
       echo "Downloading MATLAB Compiler Runtime ..."
       {% if matlabmcr.version == "2010a" -%}
       {{ matlabmcr.install_debs() }}
-      curl {{ matlabmcr.curl_opts }} -o /tmp/MCRInstaller.bin {{ matlabmcr.binaries_url }}
-      chmod +x /tmp/MCRInstaller.bin
-      /tmp/MCRInstaller.bin -silent -P installLocation="{{ matlabmcr.install_path }}"
+      curl {{ matlabmcr.curl_opts }} -o "$TMPDIR/MCRInstaller.bin" {{ matlabmcr.binaries_url }}
+      chmod +x "$TMPDIR/MCRInstaller.bin"
+      "$TMPDIR/MCRInstaller.bin" -silent -P installLocation="{{ matlabmcr.install_path }}"
       {% else -%}
-      curl {{ matlabmcr.curl_opts }} -o /tmp/mcr.zip {{ matlabmcr.binaries_url }}
-      unzip -q /tmp/mcr.zip -d /tmp/mcrtmp
-      /tmp/mcrtmp/install -destinationFolder {{ matlabmcr.install_path }} -mode silent -agreeToLicense yes
+      curl {{ matlabmcr.curl_opts }} -o "$TMPDIR/mcr.zip" {{ matlabmcr.binaries_url }}
+      unzip -q "$TMPDIR/mcr.zip" -d "$TMPDIR/mcrtmp"
+      "$TMPDIR/mcrtmp/install" -destinationFolder {{ matlabmcr.install_path }} -mode silent -agreeToLicense yes
       {% endif -%}
-      rm -rf /tmp/*
+      rm -rf "$TMPDIR"
+      unset TMPDIR

--- a/neurodocker/templates/minc.yaml
+++ b/neurodocker/templates/minc.yaml
@@ -31,4 +31,4 @@ generic:
       unzip /tmp/mni_90c.zip -d {{ minc.install_path }}/share/icbm152_model_09c
       sed -i 's+MINC_TOOLKIT=/opt/minc+MINC_TOOLKIT={{ minc.install_path }}+g' {{ minc.install_path }}/minc-toolkit-config.sh
       sed -i '$isource {{ minc.install_path }}/minc-toolkit-config.sh' $ND_ENTRYPOINT
-      rm -rf /tmp/*
+      rm -rf /tmp/mni*


### PR DESCRIPTION
Removing everything beneath these directories causes issues when using singularity. Singularity mounts some build-time directories to /tmp and maybe /var/tmp, so removing these directories attempts to remove those files on the host. See https://github.com/sylabs/singularity/issues/2538 for more info on singularity's intended behavior. See https://github.com/kaczmarj/neurodocker/issues/246 for @yarikoptic discovery and disucssion of the issue.

@yarikoptic - i removed all references to `rm -rf /tmp/* /var/tmp/*`. let me know if you want to try this pr before i merge