### PR TITLE
BF: use snapshots.debian.org instead of mirrors.kernel.org for guaranteed availability

### DIFF
--- a/neurodocker/templates/afni.yaml
+++ b/neurodocker/templates/afni.yaml
@@ -23,7 +23,7 @@ generic:
         tcsh xorg-x11-fonts-misc xorg-x11-server-Xvfb
       debs:
         - http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
-        - http://mirrors.kernel.org/debian/pool/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb
+        - http://snapshot.debian.org/archive/debian-security/20160113T213056Z/pool/updates/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb
     instructions: |
       {{ afni.install_dependencies() }}
       {{ afni.install_debs() }}
@@ -57,7 +57,7 @@ generic:
         openmotif-devel R R-devel tcsh zlib-devel
       debs:
         - http://mirrors.kernel.org/debian/pool/main/libx/libxp/libxp6_1.0.2-2_amd64.deb
-        - http://mirrors.kernel.org/debian/pool/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb
+        - http://snapshot.debian.org/archive/debian-security/20160113T213056Z/pool/updates/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb
     instructions: |
       {{ afni.install_dependencies() }}
       {{ afni.install_debs() }}


### PR DESCRIPTION
of elderly libpng12-0 pkg

atm old link is a bust
```
$> wget -O- http://mirrors.kernel.org/debian/pool/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb | head
--2019-04-10 13:15:56--  http://mirrors.kernel.org/debian/pool/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb
Resolving mirrors.kernel.org (mirrors.kernel.org)... 198.145.21.9, 2001:19d0:306:6:0:1994:3:14
Connecting to mirrors.kernel.org (mirrors.kernel.org)|198.145.21.9|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: http://mirrors.edge.kernel.org/debian/pool/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb [following]
--2019-04-10 13:15:56--  http://mirrors.edge.kernel.org/debian/pool/main/libp/libpng/libpng12-0_1.2.49-1%2Bdeb7u2_amd64.deb
Resolving mirrors.edge.kernel.org (mirrors.edge.kernel.org)... 147.75.197.195, 2604:1380:1:3600::1
Connecting to mirrors.edge.kernel.org (mirrors.edge.kernel.org)|147.75.197.195|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2019-04-10 13:15:56 ERROR 404: Not Found.
```
which is not unexpected since that debian release is gone, so might only be present in archives or snapshots