### PR TITLE
ENH: remove `license_path` directive for FreeSurfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ Note: it is not yet possible to minimize Docker containers using the _Neurodocke
 |                             | method           | binaries (default)                                                                                                                                  |
 |                             | install_path     | Installation path. Default `/opt/freesurfer-{version}`.                                                                                             |
 |                             | exclude_paths    | Sequence of space-separated path(s) to exclude when inflating the tarball.                                                                          |
-|                             | license_path     | Relative path to license file. If provided, this file will be copied into the Docker image. Must be within the build context.                       |
 | **FSL\*\***                 | version\*        | 5.0.11, 5.0.10, 5.0.9, 5.0.8                                                                                                                        |
 |                             | method           | binaries (default)                                                                                                                                  |
 |                             | install_path     | Installation path. Default `/opt/fsl-{version}`.                                                                                                    |
@@ -281,6 +280,9 @@ $ reprounzip docker setup neurodocker-reprozip.rpz test
   - Solution: do not use the `-t/--tty` flag, unless using the container interactively.
 - Attempting to rebuild into an existing Singularity image may raise an error.
   - Solution: remove the existing image or build a new image file.
-- The default apt --install option "--no-install-recommends" (that aims at minimizing container sizes) can cause a strange behaviour for cython inside the container
-  - Solution: use "--install apt_opts=`--quiet` "
-  - more information: [examples](examples#--install)
+- The default apt `--install` option `--no-install-recommends` (that aims at minimizing container sizes) can cause unexpected behavior.
+  - Solution: use `--install apt_opts="--quiet"`
+  - Please see the [examples](examples#--install) for more information.
+- FreeSurfer cannot find my license file.
+  - Solution: get a free license from [FreeSurfer's website](https://surfer.nmr.mgh.harvard.edu/registration.html), and copy it into the container. To build the Docker image, please use the form `docker build .` instead of `docker build - < Dockerfile`. The latter form will not copy files into the image.
+  - Please see the [examples](examples#freesurfer) for more information.

--- a/examples/README.md
+++ b/examples/README.md
@@ -259,13 +259,19 @@ neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=ap
 
 ## FreeSurfer
 
+Many FreeSurfer tools require a (no-cost) FreeSurfer license. These examples include copying the license file into the container.
+
 ```shell
 neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \
-  --freesurfer version=6.0.0 method=binaries
+  --freesurfer version=6.0.0 method=binaries --copy license.txt /opt/freesurfer-6.0.0/
 
 # Install version minimized for recon-all
 neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \
   --freesurfer version=6.0.0-min method=binaries
+
+# Copy FreeSurfer license to arbitrary path and set FS_LICENSE.
+neurodocker generate [docker|singularity] --base=debian:stretch --pkg-manager=apt \
+  --freesurfer version=6.0.0 method=binaries --copy license.txt / --env FS_LICENSE=/license.txt
 ```
 
 ## FSL


### PR DESCRIPTION
`license_path` was a remnant from neurodocker pre-refactor. This commit removes references to it and adds examples for adding the FreeSurfer license at container build-time.