### PR TITLE
ENH: Enable version-based URL resolution to take wildcards

### DIFF
--- a/neurodocker/interfaces/_base.py
+++ b/neurodocker/interfaces/_base.py
@@ -146,7 +146,7 @@ class _Resolver:
         if self.version_has_method(version_key, 'binaries'):
             try:
                 urls = self._d[version_key]['binaries']['urls'].keys()
-                return version in urls
+                return version in urls or "*" in urls
             except KeyError:
                 raise ValueError(
                     "no binary URLs defined for version '{}'".format(version)
@@ -169,7 +169,10 @@ class _Resolver:
     def binaries_url(self, version):
         self.check_binaries_has_url(version)
         version_key = self.get_version_key(version)
-        return self._d[version_key]['binaries']['urls'][version]
+        urls = self._d[version_key]['binaries']['urls']
+        if version in urls:
+            return urls[version]
+        return urls["*"].format(version)
 
 
 class _BaseInterface:

--- a/neurodocker/templates/miniconda.yaml
+++ b/neurodocker/templates/miniconda.yaml
@@ -5,7 +5,7 @@
 generic:
   binaries:
     urls:
-      latest: https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+      "*": https://repo.continuum.io/miniconda/Miniconda3-{}-Linux-x86_64.sh
     env:
       CONDA_DIR: '{{ miniconda.install_path }}'
       PATH: '{{ miniconda.install_path }}/bin:$PATH'

--- a/neurodocker/tests/test_neurodocker.py
+++ b/neurodocker/tests/test_neurodocker.py
@@ -4,6 +4,7 @@ import json
 import io
 
 import pytest
+from unittest import mock
 
 from neurodocker.neurodocker import main
 
@@ -80,6 +81,12 @@ def test_generate_opts(capsys):
     main(args.format('--ndfreeze date=20180312').split())
     out, _ = capsys.readouterr()
     assert out.find("nd_freeze") < out.find("ND_ENTRYPOINT")
+
+    with mock.patch("neurodocker.interfaces.Miniconda._installed", False):
+        main(args.format('--miniconda create_env=newenv version=4.7.10 '
+                         'conda_install=python=3.7').split())
+    out, _ = capsys.readouterr()
+    assert "https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh" in out
 
 
 def test_generate_from_json(capsys, tmpdir):


### PR DESCRIPTION
Currently the only option is to use the latest miniconda, but for various reasons people may prefer to specify a particular version. This works around the need to specify every version. If a wildcard is set as the version key, then the value will be rendered with `.format(version)`.

This is needed to test whether the current issues with nipype are related to the latest miniconda release. The alternative is to manually add versions, which seems to doom itself to an unending string of PRs.