### PR TITLE
ENH: Add MCR 2019* and 2015aSP1

### DIFF
--- a/neurodocker/interfaces/interfaces.py
+++ b/neurodocker/interfaces/interfaces.py
@@ -143,6 +143,8 @@ class MatlabMCR(_BaseInterface):
     _pretty_name = "MATLAB MCR"
 
     _mcr_versions = {
+        '2019b': '97',
+        '2019a': '96',
         '2018b': '95',
         '2018a': '94',
         '2017b': '93',
@@ -150,6 +152,7 @@ class MatlabMCR(_BaseInterface):
         '2016b': '91',
         '2016a': '901',
         '2015b': '90',
+        '2015aSP1': '851',
         '2015a': '85',
         '2014b': '84',
         '2014a': '83',

--- a/neurodocker/templates/matlabmcr.yaml
+++ b/neurodocker/templates/matlabmcr.yaml
@@ -6,6 +6,8 @@
 generic:
   binaries:
     urls:
+      2019b: http://ssd.mathworks.com/supportfiles/downloads/R2019b/Release/1/deployment_files/installer/complete/glnxa64/MATLAB_Runtime_R2019b_Update_1_glnxa64.zip
+      2019a: https://ssd.mathworks.com/supportfiles/downloads/R2019a/Release/6/deployment_files/installer/complete/glnxa64/MATLAB_Runtime_R2019a_Update_6_glnxa64.zip
       2018b: https://ssd.mathworks.com/supportfiles/downloads/R2018b/deployment_files/R2018b/installers/glnxa64/MCR_R2018b_glnxa64_installer.zip
       2018a: https://ssd.mathworks.com/supportfiles/downloads/R2018a/deployment_files/R2018a/installers/glnxa64/MCR_R2018a_glnxa64_installer.zip
       2017b: https://ssd.mathworks.com/supportfiles/downloads/R2017b/deployment_files/R2017b/installers/glnxa64/MCR_R2017b_glnxa64_installer.zip
@@ -13,6 +15,7 @@ generic:
       2016b: https://ssd.mathworks.com/supportfiles/downloads/R2016b/deployment_files/R2016b/installers/glnxa64/MCR_R2016b_glnxa64_installer.zip
       2016a: https://ssd.mathworks.com/supportfiles/downloads/R2016a/deployment_files/R2016a/installers/glnxa64/MCR_R2016a_glnxa64_installer.zip
       2015b: https://ssd.mathworks.com/supportfiles/downloads/R2015b/deployment_files/R2015b/installers/glnxa64/MCR_R2015b_glnxa64_installer.zip
+      2015aSP1: https://ssd.mathworks.com/supportfiles/downloads/R2015a/deployment_files/R2015aSP1/installers/glnxa64/MCR_R2015aSP1_glnxa64_installer.zip
       2015a: https://ssd.mathworks.com/supportfiles/downloads/R2015a/deployment_files/R2015a/installers/glnxa64/MCR_R2015a_glnxa64_installer.zip
       2014b: https://ssd.mathworks.com/supportfiles/downloads/R2014b/deployment_files/R2014b/installers/glnxa64/MCR_R2014b_glnxa64_installer.zip
       2014a: https://ssd.mathworks.com/supportfiles/downloads/R2014a/deployment_files/R2014a/installers/glnxa64/MCR_R2014a_glnxa64_installer.zip


### PR DESCRIPTION
Retrieved from https://www.mathworks.com/products/compiler/matlab-runtime.html

Incidentally, there is a security warning for three versions:
<img width="944" alt="Screen Shot 2019-10-26 at 08 40 41" src="https://user-images.githubusercontent.com/83442/67619692-6ae08980-f7cc-11e9-8b1a-9758574a3dde.png">

May at some point want to consider how to warn users if they're installing versions with known issues and fixes.
